### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -5,16 +5,21 @@
     "packageManager": "pnpm"
   },
   "namedInputs": {
-    "default": ["{projectRoot}/**/*", "sharedGlobals"],
+    "default": [
+      "{projectRoot}/**/*",
+      "sharedGlobals"
+    ],
     "production": [
       "default",
       "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",
       "!{projectRoot}/tsconfig.spec.json",
       "!{projectRoot}/src/test-setup.[jt]s"
     ],
-    "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"]
+    "sharedGlobals": [
+      "{workspaceRoot}/.github/workflows/ci.yml"
+    ]
   },
-  "nxCloudId": "683db0535b1b475e231bbf05",
+  "nxCloudId": "6982d8d83d71bbcac691852e",
   "plugins": [
     {
       "plugin": "@nx/js/typescript",
@@ -32,7 +37,10 @@
     },
     {
       "plugin": "@nx/vite/plugin",
-      "exclude": ["apps/solid-app-start/**/*", "apps/react-app-remix/**/*"],
+      "exclude": [
+        "apps/solid-app-start/**/*",
+        "apps/react-app-remix/**/*"
+      ],
       "options": {
         "buildTargetName": "build",
         "testTargetName": "test",
@@ -92,7 +100,9 @@
     }
   },
   "sync": {
-    "disabledTaskSyncGenerators": ["@nx/js:typescript-sync"]
+    "disabledTaskSyncGenerators": [
+      "@nx/js:typescript-sync"
+    ]
   },
   "targets": {
     "local-registry": {
@@ -128,26 +138,45 @@
   "targetDefaults": {
     "dev": {
       "cache": false,
-      "dependsOn": ["^build"]
+      "dependsOn": [
+        "^build"
+      ]
     },
     "build": {
       "cache": true,
-      "inputs": ["production", "^production"],
-      "dependsOn": ["^build"]
+      "inputs": [
+        "production",
+        "^production"
+      ],
+      "dependsOn": [
+        "^build"
+      ]
     },
     "serve": {
       "cache": false,
-      "dependsOn": ["^build"]
+      "dependsOn": [
+        "^build"
+      ]
     },
     "@nx/esbuild:esbuild": {
       "cache": true,
-      "dependsOn": ["^build"],
-      "inputs": ["production", "^production"]
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "production",
+        "^production"
+      ]
     },
     "@nx/js:tsc": {
       "cache": true,
-      "dependsOn": ["^build"],
-      "inputs": ["production", "^production"]
+      "dependsOn": [
+        "^build"
+      ],
+      "inputs": [
+        "production",
+        "^production"
+      ]
     }
   },
   "generators": {


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://cloud.nx.app/orgs/684476ee4517c33e351762f8/workspaces/6982d8d83d71bbcac691852e

> [!TIP]
> Run `npx nx generate ci-workflow` if you don't have a CI script configured yet.

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.