### PR TITLE
fix: optimize nx affected and enable release token

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # Important for Nx to analyze git history
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: 📦 Install pnpm
         uses: pnpm/action-setup@v4

--- a/nx.json
+++ b/nx.json
@@ -15,9 +15,7 @@
       "!{projectRoot}/tsconfig.spec.json",
       "!{projectRoot}/src/test-setup.[jt]s"
     ],
-    "sharedGlobals": [
-      "{workspaceRoot}/.github/workflows/ci.yml"
-    ]
+    "sharedGlobals": []
   },
   "nxCloudId": "6982d8d83d71bbcac691852e",
   "plugins": [


### PR DESCRIPTION
Excludes CI workflow from sharedGlobals to prevent affecting all projects on CI changes. Updates CD workflow to use RELEASE_TOKEN for protected branch pushes.