### PR TITLE
fix(solid-effect-atom): explicit peer ranges and build/test

### DIFF
--- a/packages/solid/effect-atom/package.json
+++ b/packages/solid/effect-atom/package.json
@@ -45,8 +45,8 @@
     "vite-plugin-solid": "catalog:"
   },
   "peerDependencies": {
-    "effect": "catalog:",
-    "solid-js": "catalog:"
+    "effect": "^3.19.16",
+    "solid-js": "^1.9.11"
   },
   "dependencies": {
     "@effect-atom/atom": "catalog:"


### PR DESCRIPTION
Set explicit peerDependencies ranges for effect (^3.19.16) and solid-js (^1.9.11). Kept @effect-atom/atom as dependency via catalog. Verified build and tests succeed via Nx and Vitest.