### PR TITLE
chore(nx): include solid-effect-atom in release projects

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -77,7 +77,8 @@
       "packages/node/better-auth",
       "packages/solid/query",
       "packages/react/router-better-auth",
-      "packages/prisma"
+      "packages/prisma",
+      "packages/solid/effect-atom"
     ],
     "changelog": {
       "automaticFromRef": "HEAD~100",


### PR DESCRIPTION
Include packages/solid/effect-atom in Nx release.projects. Also add a small API alias export to @effectify/solid-effect-atom to trigger release (conventional fix commit).