### PR TITLE
fix(docs): configure Astro site/base for GitHub Pages

### DIFF
--- a/apps/docs/astro.config.ts
+++ b/apps/docs/astro.config.ts
@@ -8,6 +8,8 @@ import startlightThemeNova from "starlight-theme-nova"
 
 // https://astro.build/config
 export default defineConfig({
+  site: "https://devx-op.github.io/effectify/",
+  base: "/effectify/",
   integrations: [
     starlight({
       plugins: [


### PR DESCRIPTION
Configure base=/effectify/ and site=https://devx-op.github.io/effectify/ in apps/docs/astro.config.ts so Astro generates asset URLs within the project subpath. This fixes blocked modules due to HTML 404 responses (MIME type text/html) and ensures JS/CSS load on GitHub Pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation site configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->