### PR TITLE
fix(docs): correct internal links by setting Astro site to domain

### DIFF
--- a/apps/docs/astro.config.ts
+++ b/apps/docs/astro.config.ts
@@ -8,7 +8,7 @@ import startlightThemeNova from "starlight-theme-nova"
 
 // https://astro.build/config
 export default defineConfig({
-  site: "https://devx-op.github.io/effectify/",
+  site: "https://devx-op.github.io",
   base: "/effectify/",
   integrations: [
     starlight({


### PR DESCRIPTION
Set site to https://devx-op.github.io and base to /effectify/ so all internal links resolve under https://devx-op.github.io/effectify/. This fixes 404s when navigating to pages like /react/getting-started/.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation site URL to reflect new hosting location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->