### PR TITLE
fix(docs): relative internal links under /effectify/ base

### DIFF
--- a/apps/docs/astro.config.ts
+++ b/apps/docs/astro.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
           {
             label: "ReactJs",
             icon: "seti:react",
-            link: "/react/",
+            link: "react/",
             id: "react",
             items: [
               {
@@ -39,7 +39,7 @@ export default defineConfig({
           {
             label: "SolidJs",
             icon: "seti:sublime",
-            link: "/solid/",
+            link: "solid/",
             id: "solid",
             items: [
               {
@@ -61,7 +61,7 @@ export default defineConfig({
           {
             label: "Backend",
             icon: "bars",
-            link: "/backend/",
+            link: "backend/",
             id: "backend",
             items: [
               {
@@ -83,7 +83,7 @@ export default defineConfig({
           {
             label: "Universal",
             icon: "puzzle",
-            link: "/universal/",
+            link: "universal/",
             id: "universal",
             items: [
               {

--- a/apps/docs/src/content/docs/index.mdx
+++ b/apps/docs/src/content/docs/index.mdx
@@ -18,7 +18,7 @@ hero:
     file: ../../assets/houston.webp
   actions:
     - text: Get Started
-      link: /react/getting-started/
+      link: react/getting-started/
       icon: right-arrow
     - text: View on GitHub
       link: https://github.com/devx-op/effectify
@@ -31,7 +31,7 @@ banner:
     to follow along with development.
 ---
 
-import { Card, CardGrid } from '@astrojs/starlight/components';
+import { Card, CardGrid } from "@astrojs/starlight/components";
 
 ## What is Effectify?
 
@@ -43,37 +43,42 @@ Effectify is a comprehensive suite of packages that brings the power of [Effect]
 	<Card title="React" icon="react">
 		Effect integration with TanStack Query, comprehensive UI components, and real-time chat functionality for React applications.
 
-		[Explore React packages →](/react/)
-	</Card>
-	<Card title="SolidJS" icon="seti:sublime">
-		Reactive Effect integration optimized for SolidJS's fine-grained reactivity system with UI components and chat features.
+    	[Explore React packages →](react/)
+    </Card>
+    <Card title="SolidJS" icon="seti:sublime">
+    	Reactive Effect integration optimized for SolidJS's fine-grained reactivity system with UI components and chat features.
 
-		[Explore SolidJS packages →](/solid/)
-	</Card>
-	<Card title="Node.js Backend" icon="bars">
-		Authentication services, better-auth integration, and complete backend solutions built with Effect.
+    	[Explore SolidJS packages →](solid/)
+    </Card>
+    <Card title="Node.js Backend" icon="bars">
+    	Authentication services, better-auth integration, and complete backend solutions built with Effect.
 
-		[Explore Backend packages →](/backend/)
-	</Card>
-	<Card title="Universal" icon="puzzle">
-		Shared domain logic, types, and business rules that work across all platforms and frameworks.
+    	[Explore Backend packages →](backend/)
+    </Card>
+    <Card title="Universal" icon="puzzle">
+    	Shared domain logic, types, and business rules that work across all platforms and frameworks.
 
-		[Explore Universal packages →](/universal/)
-	</Card>
+    	[Explore Universal packages →](universal/)
+    </Card>
+
 </CardGrid>
 
 ## Key Features
 
 ### Type Safety First
+
 Every package is built with TypeScript and Effect's powerful type system, providing compile-time guarantees and excellent IDE support.
 
 ### Composable Architecture
+
 Build complex applications from simple, composable parts using Effect's functional programming patterns.
 
 ### Error Handling
+
 Robust error handling with Effect's error management system, making your applications more reliable and easier to debug.
 
 ### Cross-Platform Consistency
+
 Share business logic and types across React, SolidJS, and Node.js applications for consistent behavior.
 
 ## Quick Start
@@ -86,22 +91,23 @@ Choose your platform to get started:
 		npm install @effectify/react-query @tanstack/react-query effect
 		```
 
-		[React Quick Start →](/react/getting-started/)
-	</Card>
-	<Card title="SolidJS Application" icon="seti:sublime">
-		```bash
-		npm install @effectify/solid-query @tanstack/solid-query effect
-		```
+    	[React Quick Start →](react/getting-started/)
+    </Card>
+    <Card title="SolidJS Application" icon="seti:sublime">
+    	```bash
+    	npm install @effectify/solid-query @tanstack/solid-query effect
+    	```
 
-		[SolidJS Quick Start →](/solid/getting-started/)
-	</Card>
-	<Card title="Node.js Backend" icon="bars">
-		```bash
-		npm install @effectify/node-better-auth better-auth effect
-		```
+    	[SolidJS Quick Start →](solid/getting-started/)
+    </Card>
+    <Card title="Node.js Backend" icon="bars">
+    	```bash
+    	npm install @effectify/node-better-auth better-auth effect
+    	```
 
-		[Backend Quick Start →](/backend/getting-started/)
-	</Card>
+    	[Backend Quick Start →](backend/getting-started/)
+    </Card>
+
 </CardGrid>
 
 ## Example Applications
@@ -119,18 +125,19 @@ Explore complete example applications built with Effectify:
 	<Card title="GitHub" icon="github">
 		View source code, report issues, and contribute to the project.
 
-		[Visit GitHub →](https://github.com/devx-op/effectify)
-	</Card>
-	<Card title="Discussions" icon="comment">
-		Join the community discussions, ask questions, and share your projects.
+    	[Visit GitHub →](https://github.com/devx-op/effectify)
+    </Card>
+    <Card title="Discussions" icon="comment">
+    	Join the community discussions, ask questions, and share your projects.
 
-		[Join Discussions →](https://github.com/devx-op/effectify/discussions)
-	</Card>
-	<Card title="Effect Discord" icon="discord">
-		Connect with the broader Effect community for support and collaboration.
+    	[Join Discussions →](https://github.com/devx-op/effectify/discussions)
+    </Card>
+    <Card title="Effect Discord" icon="discord">
+    	Connect with the broader Effect community for support and collaboration.
 
-		[Join Discord →](https://discord.gg/effect-ts)
-	</Card>
+    	[Join Discord →](https://discord.gg/effect-ts)
+    </Card>
+
 </CardGrid>
 
 ## Deployment Verification


### PR DESCRIPTION
- Use relative links in landing and navigation to ensure URLs resolve under /effectify/ on GitHub Pages\n- Keep site=https://devx-op.github.io and base=/effectify/ for correct asset and link generation\n- Fixes navigation to pages like /react/getting-started/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved navigation structure across documentation sections
  * Expanded platform support information with new Universal packages section
  * Added Quick Start guides for React, SolidJS, and Backend platforms
  * Enhanced community section with new Discord community link for support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->