### PR TITLE
ci(docs): build only docs; fix affected filtering in workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -53,8 +53,13 @@ jobs:
             echo "No valid BASE commit found, building unconditionally"
             pnpm nx build "@effectify/docs"
           else
-            echo "Running nx affected build for `@effectify/docs` between ${BASE}..${HEAD}"
-            pnpm nx affected -t build --base="${BASE}" --head="${HEAD}" --projects="@effectify/docs"
+            echo "Checking if `@effectify/docs` is affected between ${BASE}..${HEAD}"
+            if pnpm nx show projects --affected --base="${BASE}" --head="${HEAD}" | grep -q "@effectify/docs"; then
+              echo "@effectify/docs is affected. Building only docs..."
+              pnpm nx build "@effectify/docs"
+            else
+              echo "@effectify/docs not affected. Skipping build."
+            fi
           fi
           if [ -d apps/docs/dist ]; then
             echo "should_deploy=true" >> "$GITHUB_OUTPUT"

--- a/apps/docs/project.json
+++ b/apps/docs/project.json
@@ -3,5 +3,32 @@
   "name": "@effectify/docs",
   "projectType": "application",
   "sourceRoot": "apps/docs/src",
-  "tags": ["docs"]
+  "tags": ["docs"],
+  "targets": {
+    "build": {
+      "executor": "nx:run-script",
+      "cache": true,
+      "inputs": ["production"],
+      "dependsOn": [],
+      "options": {
+        "script": "build"
+      }
+    },
+    "dev": {
+      "executor": "nx:run-script",
+      "cache": false,
+      "dependsOn": [],
+      "options": {
+        "script": "dev"
+      }
+    },
+    "preview": {
+      "executor": "nx:run-script",
+      "cache": false,
+      "dependsOn": [],
+      "options": {
+        "script": "preview"
+      }
+    }
+  }
 }


### PR DESCRIPTION
Summary:\n- Build only @effectify/docs by defining explicit build target without dependsOn\n- Update docs workflow to check affected projects and build docs only when affected\n\nFiles changed:\n- .github/workflows/docs.yml\n- apps/docs/project.json\n\nOutcome:\n- CI no longer builds prisma or app projects when docs change\n- Pages deploys only when docs are affected\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the documentation build pipeline to conditionally build only when documentation files are modified, reducing unnecessary build executions and improving overall CI/CD efficiency.
  * Enhanced project configuration with standardized build, development, and preview workflow targets for improved development processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->