### PR TITLE
docs(es): fix duplicated /es prefixes in localized links

### DIFF
--- a/apps/docs/src/content/docs/es/index.mdx
+++ b/apps/docs/src/content/docs/es/index.mdx
@@ -18,7 +18,7 @@ hero:
     file: ../../../assets/houston.webp
   actions:
     - text: Empezar
-      link: es/react/getting-started/
+      link: react/getting-started/
       icon: right-arrow
     - text: Ver en GitHub
       link: https://github.com/devx-op/effectify
@@ -43,22 +43,22 @@ Effectify es un conjunto integral de paquetes que lleva el poder de [Effect](htt
 	<Card title="React" icon="react">
 		Integración con TanStack Query, biblioteca de UI y funcionalidades de chat en tiempo real para aplicaciones React.
 
-    	[Explorar paquetes de React →](es/react/)
+    	[Explorar paquetes de React →](react/)
     </Card>
     <Card title="SolidJS" icon="seti:sublime">
     	Integración reactiva de Effect optimizada para el sistema de reactividad de SolidJS, con componentes de UI y chat.
 
-    	[Explorar paquetes de SolidJS →](es/solid/)
+    	[Explorar paquetes de SolidJS →](solid/)
     </Card>
     <Card title="Backend en Node.js" icon="bars">
     	Servicios de autenticación, integración con better-auth y soluciones completas de backend construidas con Effect.
 
-    	[Explorar paquetes de Backend →](es/backend/)
+    	[Explorar paquetes de Backend →](backend/)
     </Card>
     <Card title="Universal" icon="puzzle">
     	Lógica de dominio, tipos y reglas de negocio compartidas que funcionan en todas las plataformas y frameworks.
 
-    	[Explorar paquetes Universales →](es/universal/)
+    	[Explorar paquetes Universales →](universal/)
     </Card>
 
 </CardGrid>
@@ -91,21 +91,21 @@ Elige tu plataforma para comenzar:
 		npm install @effectify/react-query @tanstack/react-query effect
 		```
 
-    	[Inicio rápido React →](es/react/getting-started/)
+    	[Inicio rápido React →](react/getting-started/)
     </Card>
     <Card title="Aplicación SolidJS" icon="seti:sublime">
     	```bash
     	npm install @effectify/solid-query @tanstack/solid-query effect
     	```
 
-    	[Inicio rápido SolidJS →](es/solid/getting-started/)
+    	[Inicio rápido SolidJS →](solid/getting-started/)
     </Card>
     <Card title="Backend en Node.js" icon="bars">
     	```bash
     	npm install @effectify/node-better-auth better-auth effect
     	```
 
-    	[Inicio rápido Backend →](es/backend/getting-started/)
+    	[Inicio rápido Backend →](backend/getting-started/)
     </Card>
 
 </CardGrid>

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json,jsonc,css,scss,md,mdx}": [
       "pnpm exec oxlint --fix",
-      "pnpm exec dprint fmt"
+      "pnpm exec dprint fmt --allow-no-files"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
chore: lint-staged dprint fmt uses --allow-no-files to avoid false failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected documentation navigation links to ensure proper access across React, SolidJS, Backend, and Universal guides.

* **Chores**
  * Updated code formatting tool configuration to improve build process robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->