### PR TITLE
fix(solid-effect-atom): add exports field to package.json

### DIFF
--- a/packages/solid/effect-atom/package.json
+++ b/packages/solid/effect-atom/package.json
@@ -4,10 +4,20 @@
   "description": "Reactive toolkit for Effect with SolidJS",
   "type": "module",
   "publishConfig": {
-    "access": "public",
-    "directory": "dist"
+    "access": "public"
   },
-  "main": "index.js",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js",
+      "default": "./dist/src/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "pnpm build-esm && pnpm build-cjs && pnpm build-annotate && build-utils pack-v2",
     "test": "vitest run",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -717,7 +717,7 @@ importers:
         version: 0.5.0(@effect/experimental@0.58.0(@effect/platform@0.94.0(effect@3.19.16))(effect@3.19.16))(@effect/platform@0.94.0(effect@3.19.16))(@effect/rpc@0.73.0(@effect/platform@0.94.0(effect@3.19.16))(effect@3.19.16))(effect@3.19.16)
       '@effectify/solid-effect-atom':
         specifier: workspace:*
-        version: link:../../packages/solid/effect-atom/dist
+        version: link:../../packages/solid/effect-atom
       '@tailwindcss/vite':
         specifier: 'catalog:'
         version: 4.1.18(vite@7.3.1(@types/node@25.2.2)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2))
@@ -1167,7 +1167,6 @@ importers:
       vite-plugin-solid:
         specifier: 'catalog:'
         version: 2.11.10(@testing-library/jest-dom@6.9.1)(solid-js@1.9.11)(vite@7.3.1(@types/node@20.19.25)(jiti@2.6.1)(lightningcss@1.30.2)(terser@5.46.0)(tsx@4.20.6)(yaml@2.8.2))
-    publishDirectory: dist
 
   packages/solid/query:
     dependencies:


### PR DESCRIPTION
Adds the exports field to package.json to fix module resolution in Vite and other bundlers, pointing to the correct ./dist/src/ paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package.json configuration for the effect-atom package with explicit distribution entry points.
  * Configured main entry point and added TypeScript types to point to built output.
  * Added exports mapping for types, import, and default resolution.
  * Restricted published package contents to include only the dist directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->