### PR TITLE
feat(react-router): verify Better Auth on React Router 8

### DIFF
--- a/apps/react-router-example/tests/react-router-readiness.test.ts
+++ b/apps/react-router-example/tests/react-router-readiness.test.ts
@@ -113,4 +113,53 @@ describe("React Router final-v8 safety", () => {
       }),
     ).rejects.toThrow("You may only call `next()` once per middleware")
   })
+
+  it.each([
+    ["document", "https://effectify.dev/todo-app"],
+    [
+      "client-navigation data",
+      "https://effectify.dev/todo-app.data?_routes=routes/todo-app",
+    ],
+  ])("preserves the %s request URL through native middleware", async (_kind, url) => {
+    const seenUrls: string[] = []
+    const handler = createStaticHandler([
+      {
+        id: "todo-app",
+        path: "/todo-app.data",
+        middleware: [
+          async ({ request }, next) => {
+            seenUrls.push(request.url)
+            return next()
+          },
+        ],
+        loader: () => new Response("data", { headers: { "X-Effectify-Request": "data" } }),
+      },
+      {
+        id: "todo-document",
+        path: "/todo-app",
+        middleware: [
+          async ({ request }, next) => {
+            seenUrls.push(request.url)
+            return next()
+          },
+        ],
+        loader: () =>
+          new Response("document", {
+            headers: { "X-Effectify-Request": "document" },
+          }),
+      },
+    ])
+
+    const result = await handler.queryRoute(new Request(url), {
+      generateMiddlewareResponse: async (query) => {
+        const value = await query(new Request(url))
+        return value instanceof Response ? value : Response.json(value)
+      },
+    })
+
+    expect(result.headers.get("X-Effectify-Request")).toBe(
+      url.includes(".data") ? "data" : "document",
+    )
+    expect(seenUrls).toEqual([url])
+  })
 })

--- a/docs/react-router-latest-major-support.md
+++ b/docs/react-router-latest-major-support.md
@@ -23,3 +23,13 @@ Before publication, abort if the exact 8.2.0 family manifests, no-build migratio
 After publication, verify the registry package version, tarball metadata, peer dependencies, and release notes match the approved 8.2.0 compatibility decision, then run the published-consumer smoke and compatibility checks. Published packages are immutable: do not unpublish, retag, or mutate a release to recover. Fix defects only with a new forward version and publish it after the same pre-publication gates pass.
 
 `@effectify/react-router` is compatible with React Router `^8.2.0`; without a deliberate passing dual-major matrix, do not claim v7 support from that artifact. React Router v7 consumers must remain on the preceding Effectify release line until they complete their own v8 migration.
+
+## WU3 Better Auth and Framework Mode proof
+
+`@effectify/react-router-better-auth` now reads the existing typed loader and action argument contexts directly. Its no-build target typechecks Better Auth, the router, and node Better Auth source together; no declarations were emitted and no package version was selected. The Unreleased package changelog records the compatibility evidence while Nx release policy remains the sole version authority.
+
+Focused guard tests verify loader and action redirects retain status `302`, `Location`, and `Set-Cookie`, while successful loader/action responses retain their status and body. API handler tests verify both typed request contexts reach Better Auth unchanged.
+
+The existing no-build `migration:test` target uses React Router 8.2.0's native static handler to prove document and `.data` request URL/response behavior, including the `.data` shape used for client navigation. This is request-level evidence only: it does not claim a browser, server start, build, or build-dependent e2e result.
+
+The optional example-local server middleware remains deferred. The installed 8.2.0 types prove native server middleware has one `next()` returning `Response | void`, and the focused static-handler tests prove one-call enforcement, RouterContextProvider visibility, ordering, and Response identity. They do not prove an example-owned Effect scope finalizes on returned responses, thrown responses/errors, rejected downstream work, and interruption. Without that complete direct runtime proof, no middleware was added. No package middleware adapter, Better Auth middleware replacement, RouterContext ownership wrapper, instrumentation, Stream/Suspense, RouterProvider, or HydratedRouter wrapper was added.

--- a/packages/react/router-better-auth/CHANGELOG.md
+++ b/packages/react/router-better-auth/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Unreleased
+
+### Compatibility
+
+- Verified React Router 8.2.0 loader/action request access without unsafe context assertions. Public exports and package version remain unchanged; Nx release policy determines any future version.
+- Verified both Better Auth guard variants preserve redirect status, location, and `Set-Cookie` headers for v8-compatible requests.
+
 ## 0.5.12-alpha.0 (2026-07-11)
 
 ### 🧱 Updated Dependencies

--- a/packages/react/router-better-auth/project.json
+++ b/packages/react/router-better-auth/project.json
@@ -14,7 +14,7 @@
     "typecheck:no-build": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "tsgo --project tsconfig.lib.json --noEmit",
+        "command": "tsgo --project tsconfig.no-build.json --noEmit",
         "cwd": "packages/react/router-better-auth"
       }
     },

--- a/packages/react/router-better-auth/src/lib/handlers.ts
+++ b/packages/react/router-better-auth/src/lib/handlers.ts
@@ -11,12 +11,12 @@ const withAuthHandler = (request: Request) =>
 
 const getLoaderRequest = Effect.gen(function*() {
   const ctx = yield* LoaderArgsContext
-  return (ctx as any).request
+  return ctx.request
 })
 
 const getActionRequest = Effect.gen(function*() {
   const ctx = yield* ActionArgsContext
-  return (ctx as any).request
+  return ctx.request
 })
 
 export const betterAuthLoader = pipe(

--- a/packages/react/router-better-auth/tests/auth-guard.test.ts
+++ b/packages/react/router-better-auth/tests/auth-guard.test.ts
@@ -1,0 +1,132 @@
+import { AuthService } from "@effectify/node-better-auth"
+import { ActionArgsContext, LoaderArgsContext } from "@effectify/react-router"
+import * as Effect from "effect/Effect"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { withBetterAuthGuard, withBetterAuthGuardAction } from "../src/lib/auth-guard.js"
+import { betterAuthAction, betterAuthLoader } from "../src/lib/handlers.js"
+
+const request = new Request("https://example.test/todo-app", {
+  headers: { cookie: "session=abc123" },
+})
+
+const sessionResponse = (session: unknown) =>
+  new Response(
+    JSON.stringify({ session, user: session ? { id: "user-1" } : null }),
+    {
+      headers: { "Content-Type": "application/json" },
+    },
+  )
+
+const loaderArgs = { request, params: {}, context: {} }
+const actionArgs = { request, params: {}, context: {} }
+
+const runLoaderGuard = () =>
+  Effect.runPromise(
+    Effect.provideService(
+      withBetterAuthGuard.with({
+        redirectOnFail: "/login",
+        redirectInit: { headers: { "Set-Cookie": "returnTo=/todo-app" } },
+      })(Effect.succeed(new Response("loader-ok", { status: 201 }))),
+      LoaderArgsContext,
+      loaderArgs,
+    ),
+  )
+
+const runActionGuard = () =>
+  Effect.runPromise(
+    Effect.provideService(
+      withBetterAuthGuardAction.with({
+        redirectOnFail: "/login",
+        redirectInit: { headers: { "Set-Cookie": "returnTo=/todo-app" } },
+      })(Effect.succeed(new Response("action-ok", { status: 202 }))),
+      ActionArgsContext,
+      actionArgs,
+    ),
+  )
+
+const createAuth = () =>
+  Effect.runPromise(
+    AuthService.AuthServiceContext.pipe(
+      Effect.provide(AuthService.AuthServiceContext.layer({ baseURL: "https://example.test" })),
+    ),
+  )
+
+describe("Better Auth guard compatibility", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it.each(
+    [
+      ["loader", runLoaderGuard],
+      ["action", runActionGuard],
+    ] as const,
+  )("preserves redirect status, location, and cookies for an unauthorized %s", async (_name, run) => {
+    vi.mocked(fetch).mockResolvedValue(sessionResponse(null))
+
+    const result = await run()
+
+    expect(result.status).toBe(302)
+    expect(result.headers.get("Location")).toBe("/login")
+    expect(result.headers.get("Set-Cookie")).toBe("returnTo=/todo-app")
+  })
+
+  it.each(
+    [
+      ["loader", runLoaderGuard, 201, "loader-ok"],
+      ["action", runActionGuard, 202, "action-ok"],
+    ] as const,
+  )("preserves successful %s responses", async (_name, run, status, body) => {
+    vi.mocked(fetch).mockResolvedValue(sessionResponse({ id: "session-1" }))
+
+    const result = await run()
+
+    expect(result.status).toBe(status)
+    await expect(result.text()).resolves.toBe(body)
+  })
+
+  it("forwards the exact typed loader context request to auth.handler", async () => {
+    const request = new Request("https://example.test/api/auth/loader", {
+      headers: { cookie: "loader=session" },
+    })
+    const auth = await createAuth()
+    const authHandler = vi.spyOn(auth.auth, "handler").mockResolvedValue(new Response("loader"))
+
+    const response = await Effect.runPromise(
+      betterAuthLoader.pipe(
+        Effect.provideService(LoaderArgsContext, { request, params: {}, context: {} }),
+        Effect.provideService(AuthService.AuthServiceContext, auth),
+      ),
+    )
+
+    expect(authHandler).toHaveBeenCalledTimes(1)
+    expect(authHandler).toHaveBeenCalledWith(request)
+    expect(authHandler.mock.calls[0]?.[0]).toBe(request)
+    await expect(response.text()).resolves.toBe("loader")
+  })
+
+  it("forwards the exact typed action context request to auth.handler", async () => {
+    const request = new Request("https://example.test/api/auth/action", {
+      headers: { cookie: "action=session" },
+    })
+    const auth = await createAuth()
+    const authHandler = vi.spyOn(auth.auth, "handler").mockResolvedValue(new Response("action"))
+
+    const response = await Effect.runPromise(
+      betterAuthAction.pipe(
+        Effect.provideService(ActionArgsContext, { request, params: {}, context: {} }),
+        Effect.provideService(AuthService.AuthServiceContext, auth),
+      ),
+    )
+
+    expect(authHandler).toHaveBeenCalledTimes(1)
+    expect(authHandler).toHaveBeenCalledWith(request)
+    expect(authHandler.mock.calls[0]?.[0]).toBe(request)
+    await expect(response.text()).resolves.toBe("action")
+  })
+})

--- a/packages/react/router-better-auth/tsconfig.no-build.json
+++ b/packages/react/router-better-auth/tsconfig.no-build.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "rootDir": "../../..",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@effectify/node-better-auth": ["../../node/better-auth/src/index.ts"],
+      "@effectify/react-router": ["../router/src/index.ts"]
+    }
+  },
+  "include": [
+    "src/**/*.ts",
+    "../../node/better-auth/src/**/*.ts",
+    "../router/src/**/*.ts"
+  ]
+}


### PR DESCRIPTION
Closes #64

## Type

- [x] New feature

## Summary

- Proves Better Auth loader/action compatibility on React Router 8.
- Replaces unsafe context assertions with typed Request access and exact Request-identity tests.
- Adds no-build Better Auth typechecking and Framework request-level evidence.

## Changes

| Area | Change |
|---|---|
| `packages/react/router-better-auth` | Typed handlers, guard/API tests, changelog, no-build typecheck |
| `apps/react-router-example/tests` | Framework document/data request evidence |
| `docs/` | Final WU3 compatibility and evidence boundary |

## Test plan

- [x] Better Auth tests: 9/9
- [x] Better Auth no-build typecheck
- [x] Better Auth and example lint
- [x] Framework migration tests: 8/8
- [x] Formatting and diff checks

## Chain context

```text
dev
└─ feat/react-router-v8-wu1-wu2  core checkpoint
   └─ feat/react-router-v8-wu3   📍 current PR
```

**Start:** approved parent commit `7afbcb5`  
**End:** Better Auth and Framework compatibility proof  
**Dependency:** parent branch `feat/react-router-v8-wu1-wu2`  
**Follow-up:** merge this PR into the parent, then mark the parent tracker PR ready  
**Out of scope:** package middleware adapter, instrumentation, Stream/Suspense wrappers

## Contributor checklist

- [x] Linked approved issue #64
- [x] Exactly one `type:*` label will be applied
- [x] Relevant tests and no-build checks passed
- [x] Documentation updated
- [x] Conventional commits used
- [x] No AI attribution or Co-Authored-By trailers
