### PR TITLE
feat(hatchet): add durable task runtime

### DIFF
--- a/packages/hatchet/README.md
+++ b/packages/hatchet/README.md
@@ -36,6 +36,41 @@ const program = Hatchet.run(greet, { name: "Ada" }).pipe(
 
 `input` and `output` are optional Effect Schema codecs. Input is decoded before the task body; output is validated and encoded at the transport boundary. Boundary failures use `TaskSchemaError` with an `input` or `output` phase. Schema-free tasks remain supported.
 
+## Declarative metadata
+
+Package-owned `RateLimit` and `Trigger` values keep Hatchet SDK declaration types behind the adapter boundary. Values are immutable, validated before SDK or worker mutation, and translated without dropping duplicates or optional fields.
+
+```ts
+import { RateLimit, Task, Trigger } from "@effectify/hatchet"
+
+const notified = Task.make({
+  name: "customer-notified",
+  rateLimits: [RateLimit.make({ units: 10, duration: "minute", key: "customer" })],
+  triggers: [Trigger.event("customer:updated")],
+  fn: (input: { readonly customerId: string }) => Effect.succeed(input),
+})
+```
+
+Empty names, malformed rate limits or triggers, unknown declaration kinds, and duplicate task identities fail with `TaskDeclarationError` before registration starts.
+
+## Durable tasks
+
+`Task.durable` uses the same Effect-first Schema and requirements contract while exposing durable invocation metadata to the handler. The live adapter registers it with Hatchet's durable task API; the in-memory adapter supplies invocation count `0` for deterministic tests.
+
+```ts
+const durableGreeting = Task.durable({
+  name: "durable-greeting",
+  input: GreetingInput,
+  output: GreetingOutput,
+  fn: ({ name }, context) =>
+    Effect.succeed({
+      greeting: `Hello, ${name}! Invocation ${context.invocationCount}`,
+    }),
+})
+```
+
+Durable handlers receive `workflowRunId`, `taskRunExternalId`, `interruption`, and `invocationCount`. SDK abort signals interrupt the Effect execution, task requirements are captured when the Layer is acquired, and unknown task identities fail with `MissingTaskError` rather than dispatching another declaration.
+
 ## Dispatch without waiting
 
 `Hatchet.runNoWait(task, input)` dispatches the task and returns a scoped `RunHandle` before the task completes. Its branded `id` identifies the run, `await` produces the same Schema-decoded output as `Hatchet.run`, and `cancel` interrupts an outstanding run.
@@ -128,6 +163,9 @@ Omitting TLS strategy preserves the SDK secure default. Local plaintext Hatchet 
 ## Public API
 
 - `Task.make(options)` — declarative task identity with optional input/output Schema
+- `Task.durable(options)` — durable declaration with `Task.DurableContext`
+- `RateLimit.make(options)` — immutable rate-limit metadata
+- `Trigger.event(name)`, `Trigger.cron(expression)` — immutable trigger metadata
 - `Hatchet.layer({ tasks, options?, config? })` — package-owned lazy live Layer
 - `Hatchet.layerInMemory` — deterministic scoped adapter for tests
 - `Hatchet.run(task, input)` — await task output

--- a/packages/hatchet/src/Error.ts
+++ b/packages/hatchet/src/Error.ts
@@ -12,6 +12,32 @@ export class TaskSchemaError extends Data.TaggedError("TaskSchemaError")<{
   readonly issue: unknown
 }> {}
 
+export type TaskDeclarationFailureReason =
+  | "DuplicateIdentity"
+  | "InvalidKind"
+  | "InvalidMetadata"
+
+export class TaskDeclarationError extends Data.TaggedError(
+  "TaskDeclarationError",
+)<{
+  readonly taskName: string
+  readonly field: string
+  readonly reason: TaskDeclarationFailureReason
+  readonly index?: number
+}> {
+  constructor(args: {
+    readonly taskName: string
+    readonly field: string
+    readonly reason: TaskDeclarationFailureReason
+    readonly index?: number
+  }) {
+    super(args)
+    this.message = `Invalid task declaration ${args.field} for ${args.taskName}${
+      args.index === undefined ? "" : ` at index ${args.index}`
+    }`
+  }
+}
+
 export class InvalidHatchetConfiguration extends Schema.TaggedErrorClass<InvalidHatchetConfiguration>()(
   "InvalidHatchetConfiguration",
   {

--- a/packages/hatchet/src/Hatchet.ts
+++ b/packages/hatchet/src/Hatchet.ts
@@ -20,6 +20,7 @@ import {
   type InvalidHatchetConfiguration,
   InvalidTimeError,
   type MissingTaskError,
+  type TaskDeclarationError,
   TaskSchemaError,
 } from "./Error.js"
 import {
@@ -74,10 +75,11 @@ export type AcquisitionError =
   | HatchetConfigError
   | InvalidHatchetConfiguration
   | HatchetSdkError
+  | TaskDeclarationError
 
 export interface Service {
   readonly run: <Name extends string, Input, Output, Error, Requirements>(
-    task: Task.Task<Name, Input, Output, Error, Requirements>,
+    task: Task.Of<Name, Input, Output, Error, Requirements>,
     input: unknown,
   ) => Effect.Effect<
     Output,
@@ -85,7 +87,7 @@ export interface Service {
     Requirements
   >
   readonly runNoWait: <Name extends string, Input, Output, Error, Requirements>(
-    task: Task.Task<Name, Input, Output, Error, Requirements>,
+    task: Task.Of<Name, Input, Output, Error, Requirements>,
     input: unknown,
   ) => Effect.Effect<
     RunHandle<Output, Error>,
@@ -93,7 +95,7 @@ export interface Service {
     Requirements
   >
   readonly schedule: <Name extends string, Input, Output, Error, Requirements>(
-    task: Task.Task<Name, Input, Output, Error, Requirements>,
+    task: Task.Of<Name, Input, Output, Error, Requirements>,
     input: unknown,
     timing: ScheduleTiming,
   ) => Effect.Effect<
@@ -115,7 +117,7 @@ export interface Service {
     Error,
     Requirements,
   >(
-    task: Task.Task<Name, Input, Output, Error, Requirements>,
+    task: Task.Of<Name, Input, Output, Error, Requirements>,
     options: CreateCronOptions,
   ) => Effect.Effect<
     CronRecord,
@@ -155,7 +157,7 @@ const makeInMemoryService = (ownerScope: Scope.Scope): Service => {
   let nextCronId = 1
 
   const ensureTask = <Name extends string, Input, Output, Error, Requirements>(
-    task: Task.Task<Name, Input, Output, Error, Requirements>,
+    task: Task.Of<Name, Input, Output, Error, Requirements>,
   ): Effect.Effect<void, never, Requirements> =>
     Effect.gen(function*() {
       if (tasks.has(task.name)) return
@@ -188,11 +190,15 @@ const makeInMemoryService = (ownerScope: Scope.Scope): Service => {
     Error,
     Requirements,
   >(
-    task: Task.Task<Name, Input, Output, Error, Requirements>,
+    task: Task.Of<Name, Input, Output, Error, Requirements>,
     input: Input,
     context: Task.Context,
   ) =>
-    Effect.scoped(task.execute(input, context)).pipe(
+    Effect.scoped(
+      task._tag === "Durable"
+        ? task.execute(input, { ...context, invocationCount: 0 })
+        : task.execute(input, context),
+    ).pipe(
       Effect.tap((output) =>
         task.outputSchema
           ? Schema.encodeUnknownEffect(task.outputSchema)(output).pipe(
@@ -213,7 +219,7 @@ const makeInMemoryService = (ownerScope: Scope.Scope): Service => {
     Error,
     Requirements,
   >(
-    task: Task.Task<Name, Input, Output, Error, Requirements>,
+    task: Task.Of<Name, Input, Output, Error, Requirements>,
     input: unknown,
   ): Effect.Effect<
     PreparedExecution<Output, Error, Requirements>,
@@ -236,7 +242,7 @@ const makeInMemoryService = (ownerScope: Scope.Scope): Service => {
   }
 
   const runNoWait = <Name extends string, Input, Output, Error, Requirements>(
-    task: Task.Task<Name, Input, Output, Error, Requirements>,
+    task: Task.Of<Name, Input, Output, Error, Requirements>,
     input: unknown,
   ): Effect.Effect<
     RunHandle<Output, Error>,
@@ -247,25 +253,43 @@ const makeInMemoryService = (ownerScope: Scope.Scope): Service => {
       yield* ensureTask(task)
       const prepared = yield* prepareInput(task, input)
       const execution = nextContext()
-      const fiber = yield* Effect.forkIn(
-        prepared(execution.context),
-        ownerScope,
-      )
       const id = makeRunId(execution.id)
       const remove = Effect.sync(() => runs.delete(id))
-      runs.set(id, fiber)
-      return {
-        id,
-        await: Fiber.join(fiber).pipe(Effect.ensuring(remove)),
-        cancel: Fiber.interrupt(fiber).pipe(
-          Effect.asVoid,
-          Effect.ensuring(remove),
-        ),
-      }
+      const registered = yield* Deferred.make<void>()
+      return yield* Effect.uninterruptibleMask((restore) =>
+        Effect.gen(function*() {
+          const fiber = yield* Effect.forkIn(
+            Deferred.await(registered).pipe(
+              Effect.andThen(prepared(execution.context)),
+              Effect.ensuring(remove),
+              Effect.interruptible,
+            ),
+            ownerScope,
+          )
+          runs.set(id, fiber)
+          yield* Deferred.succeed(registered, undefined)
+          const handle = {
+            id,
+            await: Fiber.join(fiber).pipe(Effect.ensuring(remove)),
+            cancel: Fiber.interrupt(fiber).pipe(
+              Effect.asVoid,
+              Effect.ensuring(remove),
+            ),
+          }
+          return yield* restore(Effect.succeed(handle)).pipe(
+            Effect.onInterrupt(() =>
+              Fiber.interrupt(fiber).pipe(
+                Effect.asVoid,
+                Effect.ensuring(remove),
+              )
+            ),
+          )
+        })
+      )
     })
 
   const schedule = <Name extends string, Input, Output, Error, Requirements>(
-    task: Task.Task<Name, Input, Output, Error, Requirements>,
+    task: Task.Of<Name, Input, Output, Error, Requirements>,
     input: unknown,
     timing: ScheduleTiming,
   ): Effect.Effect<
@@ -311,7 +335,7 @@ const makeInMemoryService = (ownerScope: Scope.Scope): Service => {
     })
 
   const createCron = <Name extends string, Input, Output, Error, Requirements>(
-    task: Task.Task<Name, Input, Output, Error, Requirements>,
+    task: Task.Of<Name, Input, Output, Error, Requirements>,
     options: CreateCronOptions,
   ): Effect.Effect<
     CronRecord,
@@ -578,7 +602,7 @@ export const layer = <const Tasks extends ReadonlyArray<Task.Any>>(
   )
 
 export const run = <Name extends string, Input, Output, Error, Requirements>(
-  task: Task.Task<Name, Input, Output, Error, Requirements>,
+  task: Task.Of<Name, Input, Output, Error, Requirements>,
   input: unknown,
 ): Effect.Effect<
   Output,
@@ -593,7 +617,7 @@ export const runNoWait = <
   Error,
   Requirements,
 >(
-  task: Task.Task<Name, Input, Output, Error, Requirements>,
+  task: Task.Of<Name, Input, Output, Error, Requirements>,
   input: unknown,
 ): Effect.Effect<
   RunHandle<Output, Error>,
@@ -608,7 +632,7 @@ export const schedule = <
   Error,
   Requirements,
 >(
-  task: Task.Task<Name, Input, Output, Error, Requirements>,
+  task: Task.Of<Name, Input, Output, Error, Requirements>,
   input: unknown,
   timing: ScheduleTiming,
 ): Effect.Effect<
@@ -637,7 +661,7 @@ export const createCron = <
   Error,
   Requirements,
 >(
-  task: Task.Task<Name, Input, Output, Error, Requirements>,
+  task: Task.Of<Name, Input, Output, Error, Requirements>,
   options: CreateCronOptions,
 ): Effect.Effect<
   CronRecord,

--- a/packages/hatchet/src/Task.ts
+++ b/packages/hatchet/src/Task.ts
@@ -76,7 +76,11 @@ export interface DurableTask<
   ): Effect.Effect<Output, Error, Requirements>
 }
 
-export type Any<Requirements = unknown> = Task<
+export type Of<Name extends string, Input, Output, Error, Requirements> =
+  | Task<Name, Input, Output, Error, Requirements>
+  | DurableTask<Name, Input, Output, Error, Requirements>
+
+export type Any<Requirements = unknown> = Of<
   string,
   unknown,
   unknown,
@@ -84,14 +88,9 @@ export type Any<Requirements = unknown> = Task<
   Requirements
 >
 
-export type Declaration<Requirements = unknown> =
-  | Any<Requirements>
-  | DurableTask<string, unknown, unknown, unknown, Requirements>
+export type Declaration<Requirements = unknown> = Any<Requirements>
 
-export type Requirements<T> = T extends
-  | Task<string, unknown, unknown, unknown, infer R>
-  | DurableTask<string, unknown, unknown, unknown, infer R> ? R
-  : never
+export type Requirements<T> = T extends Of<string, unknown, unknown, unknown, infer R> ? R : never
 
 export interface MakeOptions<
   Name extends string,

--- a/packages/hatchet/src/index.ts
+++ b/packages/hatchet/src/index.ts
@@ -1,5 +1,7 @@
 export * as CronExpression from "./CronExpression.js"
 export * as Task from "./Task.js"
+export * as RateLimit from "./RateLimit.js"
+export * as Trigger from "./Trigger.js"
 export * as Hatchet from "./Hatchet.js"
 export * as HatchetConfig from "./HatchetConfig.js"
 export * from "./Error.js"

--- a/packages/hatchet/src/internal/declaration-validation.ts
+++ b/packages/hatchet/src/internal/declaration-validation.ts
@@ -1,23 +1,25 @@
-import type * as RateLimit from "../RateLimit.js"
+import type { Duration as RateLimitDuration, RateLimit as RateLimitValue } from "../RateLimit.js"
 import type * as Trigger from "../Trigger.js"
+import { TaskDeclarationError } from "../Error.js"
+import type * as Task from "../Task.js"
 
-export class InvalidRateLimitError extends Error {
-  readonly _tag = "InvalidRateLimitError"
-
-  constructor(
-    readonly taskName: string,
-    readonly index: number,
-    readonly field: string,
-  ) {
-    super(`Invalid rate limit ${field} for task ${taskName} at index ${index}`)
-  }
-}
+const invalid = (
+  taskName: string,
+  field: string,
+  index?: number,
+): TaskDeclarationError =>
+  new TaskDeclarationError({
+    taskName,
+    field,
+    reason: "InvalidMetadata",
+    ...(index === undefined ? {} : { index }),
+  })
 
 const isPositiveSafeInteger = (value: number): boolean => Number.isSafeInteger(value) && value > 0
 
 const isNonEmpty = (value: string): boolean => value.trim().length > 0
 
-const isDuration = (value: unknown): value is RateLimit.Duration =>
+const isDuration = (value: unknown): value is RateLimitDuration =>
   value === "second" ||
   value === "minute" ||
   value === "hour" ||
@@ -37,7 +39,7 @@ const validateNumberOrExpression = (
     (typeof value === "number" && !isPositiveSafeInteger(value)) ||
     (typeof value === "string" && !isNonEmpty(value))
   ) {
-    throw new InvalidRateLimitError(taskName, index, field)
+    throw invalid(taskName, field, index)
   }
 }
 
@@ -48,21 +50,21 @@ const validateText = (
   value: string | undefined,
 ): void => {
   if (value !== undefined && !isNonEmpty(value)) {
-    throw new InvalidRateLimitError(taskName, index, field)
+    throw invalid(taskName, field, index)
   }
 }
 
 export const rateLimits = (
   taskName: string,
-  values: ReadonlyArray<RateLimit.RateLimit>,
-): ReadonlyArray<RateLimit.RateLimit> => {
+  values: ReadonlyArray<RateLimitValue>,
+): ReadonlyArray<RateLimitValue> => {
   for (const [index, value] of values.entries()) {
     validateNumberOrExpression(taskName, index, "units", value.units)
     if (value.limit !== undefined) {
       validateNumberOrExpression(taskName, index, "limit", value.limit)
     }
     if (value.duration !== undefined && !isDuration(value.duration)) {
-      throw new InvalidRateLimitError(taskName, index, "duration")
+      throw invalid(taskName, "duration", index)
     }
     validateText(taskName, index, "key", value.key)
     validateText(taskName, index, "staticKey", value.staticKey)
@@ -81,13 +83,49 @@ export const triggers = (
         value.event.trim().length === 0 ||
         /[\u0000-\u001f\u007f]/.test(value.event)
       ) {
-        throw new InvalidRateLimitError(taskName, index, "event")
+        throw invalid(taskName, "event", index)
       }
       continue
     }
     if (value._tag !== "Cron") {
-      throw new InvalidRateLimitError(taskName, index, "trigger")
+      throw invalid(taskName, "trigger", index)
     }
+  }
+  return values
+}
+
+export const declarations = <Requirements>(
+  values: ReadonlyArray<Task.Any<Requirements>>,
+): ReadonlyArray<Task.Any<Requirements>> => {
+  const names = new Set<string>()
+  for (const [index, value] of values.entries()) {
+    const taskName = typeof value?.name === "string" ? value.name : "<unknown>"
+    if (value?._tag !== "Ordinary" && value?._tag !== "Durable") {
+      throw new TaskDeclarationError({
+        taskName,
+        field: "_tag",
+        reason: "InvalidKind",
+        index,
+      })
+    }
+    if (taskName.trim().length === 0) throw invalid(taskName, "name", index)
+    if (names.has(taskName)) {
+      throw new TaskDeclarationError({
+        taskName,
+        field: "name",
+        reason: "DuplicateIdentity",
+        index,
+      })
+    }
+    if (!Array.isArray(value.rateLimits)) {
+      throw invalid(taskName, "rateLimits", index)
+    }
+    if (!Array.isArray(value.triggers)) {
+      throw invalid(taskName, "triggers", index)
+    }
+    rateLimits(taskName, value.rateLimits)
+    triggers(taskName, value.triggers)
+    names.add(taskName)
   }
   return values
 }

--- a/packages/hatchet/src/internal/live.ts
+++ b/packages/hatchet/src/internal/live.ts
@@ -17,6 +17,7 @@ import {
   InvalidHatchetConfiguration,
   InvalidTimeError,
   MissingTaskError,
+  TaskDeclarationError,
   TaskSchemaError,
 } from "../Error.js"
 import * as Hatchet from "../Hatchet.js"
@@ -129,7 +130,10 @@ const isAmbiguousCronCreateCause = (cause: unknown, depth = 0): boolean => {
         typeof cause.response.status === "number"
     ? cause.response.status
     : undefined
-  if (status === 408 || (status !== undefined && status >= 500 && status < 600)) {
+  if (
+    status === 408 ||
+    (status !== undefined && status >= 500 && status < 600)
+  ) {
     return true
   }
   if (
@@ -354,66 +358,86 @@ const makeService = <Requirements>(
     let closing = false
 
     const addDeclaration = <Name extends string, Input, Output, Error>(
-      task: Task.Task<Name, Input, Output, Error, Requirements>,
+      task: Task.Of<Name, Input, Output, Error, Requirements>,
       context: Context.Context<Requirements>,
     ) => {
       tasks.add(task, context)
       const rateLimits = SdkDeclaration.rateLimits(task.rateLimits)
       const on = SdkDeclaration.on(task.triggers)
-      const declaration = client.task<JsonObject, LiveOutputEnvelope>({
+      const fn = (
+        input: JsonObject,
+        sdkContext: {
+          readonly workflowRunId: () => string
+          readonly taskRunExternalId: () => string
+          readonly abortController: AbortController
+          readonly invocationCount?: number
+        },
+      ) => {
+        const baseContext = {
+          workflowRunId: Option.some(sdkContext.workflowRunId()),
+          taskRunExternalId: Option.some(sdkContext.taskRunExternalId()),
+          interruption: abortSignalEffect(sdkContext.abortController.signal),
+        }
+        const stored = tasks.run<Output, Error>(
+          task.name,
+          input,
+          task._tag === "Durable"
+            ? {
+              ...baseContext,
+              invocationCount: sdkContext.invocationCount ?? 0,
+            }
+            : baseContext,
+        )
+        if (!stored) {
+          return Promise.reject(new MissingTaskError({ taskName: task.name }))
+        }
+        const encoded = Effect.raceFirst(
+          abortSignalEffect(sdkContext.abortController.signal),
+          stored,
+        ).pipe(
+          Effect.flatMap((value) =>
+            task.outputSchema
+              ? Schema.encodeUnknownEffect(task.outputSchema)(value).pipe(
+                Effect.mapError(
+                  (issue) =>
+                    new TaskSchemaError({
+                      taskName: task.name,
+                      phase: "output",
+                      issue,
+                    }),
+                ),
+              )
+              : Effect.succeed(value)
+          ),
+        )
+        return Effect.runPromiseExit(Effect.scoped(encoded)).then((exit) => {
+          if (!Exit.isSuccess(exit)) throw new LiveCallbackError(exit.cause)
+          if (!isTransportValue(exit.value)) {
+            throw new LiveCallbackError(
+              Cause.die(
+                new TypeError("live callback output is not transportable"),
+              ),
+            )
+          }
+          return { value: exit.value }
+        })
+      }
+      const declarationOptions = {
         name: task.name,
         ...(rateLimits.length === 0 ? {} : { rateLimits }),
         ...(on === undefined ? {} : { on }),
-        fn: (input, sdkContext) => {
-          const stored = tasks.run<Output, Error>(task.name, input, {
-            workflowRunId: Option.some(sdkContext.workflowRunId()),
-            taskRunExternalId: Option.some(sdkContext.taskRunExternalId()),
-            interruption: abortSignalEffect(sdkContext.abortController.signal),
-          })
-          if (!stored) {
-            return Promise.reject(new Error(`Missing task: ${task.name}`))
-          }
-          const encoded = Effect.raceFirst(
-            abortSignalEffect(sdkContext.abortController.signal),
-            stored,
-          ).pipe(
-            Effect.flatMap((value) =>
-              task.outputSchema
-                ? Schema.encodeUnknownEffect(task.outputSchema)(value).pipe(
-                  Effect.mapError(
-                    (issue) =>
-                      new TaskSchemaError({
-                        taskName: task.name,
-                        phase: "output",
-                        issue,
-                      }),
-                  ),
-                )
-                : Effect.succeed(value)
-            ),
-          )
-          return Effect.runPromiseExit(Effect.scoped(encoded)).then((exit) => {
-            if (!Exit.isSuccess(exit)) throw new LiveCallbackError(exit.cause)
-            if (!isTransportValue(exit.value)) {
-              throw new LiveCallbackError(
-                Cause.die(
-                  new TypeError("live callback output is not transportable"),
-                ),
-              )
-            }
-            return { value: exit.value }
-          })
-        },
-      })
+        fn,
+      }
+      const declaration = task._tag === "Durable"
+        ? client.durableTask<JsonObject, LiveOutputEnvelope>(
+          declarationOptions,
+        )
+        : client.task<JsonObject, LiveOutputEnvelope>(declarationOptions)
       declarations.set(task.name, declaration)
       taskIdentities.add(task)
     }
 
     const context = yield* Effect.context<Requirements>()
-    for (const task of declarationsToLoad) {
-      Declarations.rateLimits(task.name, task.rateLimits)
-      Declarations.triggers(task.name, task.triggers)
-    }
     for (const task of declarationsToLoad) addDeclaration(task, context)
 
     let startFiber: Fiber.Fiber<void, HatchetSdkError> | undefined
@@ -515,7 +539,7 @@ const makeService = <Requirements>(
       Error,
       TaskRequirements,
     >(
-      task: Task.Task<Name, Input, Output, Error, TaskRequirements>,
+      task: Task.Of<Name, Input, Output, Error, TaskRequirements>,
       input: unknown,
       operation: string,
     ): Effect.Effect<
@@ -661,13 +685,15 @@ const makeService = <Requirements>(
           return yield* result.failure
         }
         const reconciled = yield* reconcileCronCreateWithinBound(
-          () =>
-            client.crons.list({
+          () => {
+            const filters = {
               workflow: task.name,
-              ...{ name: cronOptions.name },
+              name: cronOptions.name,
               offset: 0,
               limit: 2,
-            }),
+            }
+            return client.crons.list(filters)
+          },
           task.name,
           cronOptions.name,
         )
@@ -829,12 +855,26 @@ export const layer = <Requirements>(
   tasks: ReadonlyArray<Task.Any<Requirements>>,
 ): Layer.Layer<
   Hatchet.Hatchet,
-  InvalidHatchetConfiguration | HatchetConfigError | HatchetSdkError,
+  | InvalidHatchetConfiguration
+  | HatchetConfigError
+  | HatchetSdkError
+  | TaskDeclarationError,
   Requirements
 > =>
   Layer.effect(Hatchet.Hatchet)(
     Effect.gen(function*() {
       yield* validate(options)
+      yield* Effect.try({
+        try: () => Declarations.declarations(tasks),
+        catch: (cause) =>
+          cause instanceof TaskDeclarationError
+            ? cause
+            : new TaskDeclarationError({
+              taskName: "<unknown>",
+              field: "declaration",
+              reason: "InvalidMetadata",
+            }),
+      })
       const client = options.client
       const sdkClient = yield* Effect.try({
         try: () =>

--- a/packages/hatchet/src/internal/registry.ts
+++ b/packages/hatchet/src/internal/registry.ts
@@ -8,19 +8,19 @@ import type * as Task from "../Task.js"
 interface StoredTask {
   readonly run: (
     input: unknown,
-    taskContext: Task.Context,
+    taskContext: Task.Context | Task.DurableContext,
   ) => Effect.Effect<unknown, unknown | TaskSchemaError, unknown>
 }
 
 export interface Registry {
   readonly add: <Name extends string, Input, Output, Error, Requirements>(
-    task: Task.Task<Name, Input, Output, Error, Requirements>,
+    task: Task.Of<Name, Input, Output, Error, Requirements>,
     context: Context.Context<Requirements>,
   ) => void
   readonly run: <Output, Error>(
     name: string,
     input: unknown,
-    taskContext: Task.Context,
+    taskContext: Task.Context | Task.DurableContext,
   ) => Effect.Effect<Output, Error | TaskSchemaError> | undefined
   readonly has: (name: string) => boolean
 }
@@ -32,7 +32,7 @@ const makeStoredTask = <
   Error,
   Requirements,
 >(
-  task: Task.Task<Name, Input, Output, Error, Requirements>,
+  task: Task.Of<Name, Input, Output, Error, Requirements>,
   context: Context.Context<Requirements>,
 ): StoredTask => ({
   run: (input, taskContext) =>
@@ -50,12 +50,19 @@ const makeStoredTask = <
           ),
         )
         : (input as Input)
-      const output = yield* task
-        .execute(decoded, taskContext)
-        .pipe(
-          Effect.provideService(Scope.Scope, taskScope),
-          Effect.provideContext(context),
-        )
+      const output = yield* (
+        task._tag === "Durable"
+          ? task.execute(decoded, {
+            ...taskContext,
+            invocationCount: "invocationCount" in taskContext
+              ? taskContext.invocationCount
+              : 0,
+          })
+          : task.execute(decoded, taskContext)
+      ).pipe(
+        Effect.provideService(Scope.Scope, taskScope),
+        Effect.provideContext(context),
+      )
       if (task.outputSchema) {
         yield* Schema.encodeUnknownEffect(task.outputSchema)(output).pipe(
           Effect.mapError(
@@ -83,7 +90,7 @@ export const make = (): Registry => {
     run: <Output, Error>(
       name: string,
       input: unknown,
-      taskContext: Task.Context,
+      taskContext: Task.Context | Task.DurableContext,
     ) => {
       const task = tasks.get(name)
       // The heterogeneous map erases task-specific I/O/E/R only here. Public callers

--- a/packages/hatchet/tests/types/declarative-task-api.ts
+++ b/packages/hatchet/tests/types/declarative-task-api.ts
@@ -1,7 +1,7 @@
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import * as Schema from "effect/Schema"
-import { Task } from "@effectify/hatchet"
+import { RateLimit, Task, TaskDeclarationError, Trigger } from "@effectify/hatchet"
 
 class Dependency extends Context.Service<
   Dependency,
@@ -27,9 +27,11 @@ const ordinary: Task.Task<"ordinary", Input, Output, Failure, Dependency> = Task
 
 const durable = Task.durable({
   name: "durable",
-  fn: (_input: Input, context) => {
+  fn: (_input: Input, context): Effect.Effect<Output, never, Dependency> => {
     const count: number = context.invocationCount
-    return Effect.succeed({ rendered: String(count) })
+    return Effect.map(Dependency, ({ value }) => ({
+      rendered: `${value}:${count}`,
+    }))
   },
 })
 
@@ -41,3 +43,10 @@ durable.execute({ value: 1 }, Task.DurableContext.empty).sleepFor
 ordinary.execute({ value: 1 }, Task.DurableContext.empty).invocationCount
 
 void mixed
+void RateLimit.make({ units: 1, duration: "minute" })
+void Trigger.event("customer:updated")
+void new TaskDeclarationError({
+  taskName: "ordinary",
+  field: "name",
+  reason: "DuplicateIdentity",
+})

--- a/packages/hatchet/tests/unit/live-sdk-port.test.ts
+++ b/packages/hatchet/tests/unit/live-sdk-port.test.ts
@@ -38,6 +38,7 @@ const sdk = vi.hoisted(() => {
     cancel,
   }))
   const task = vi.fn((declaration) => ({ ...declaration, runNoWait }))
+  const durableTask = vi.fn((declaration) => ({ ...declaration, runNoWait }))
   const crons = {
     create: vi.fn(async (name: string) => ({
       metadata: { id: "cron-42" },
@@ -54,12 +55,14 @@ const sdk = vi.hoisted(() => {
     events,
     init: vi.fn(() => ({
       task,
+      durableTask,
       worker,
       crons,
       scheduled: { create: vi.fn(), get: vi.fn(), delete: vi.fn() },
       runs: { cancel: vi.fn() },
     })),
     task,
+    durableTask,
     worker,
     registerWorkflows,
     start,
@@ -92,9 +95,16 @@ const upper = Task.make({
   fn: ({ value }) => Effect.succeed(value.toUpperCase()),
 })
 
+const durableUpper = Task.durable({
+  name: "durable-upper",
+  input: Schema.Struct({ value: Schema.String }),
+  output: Schema.NonEmptyString,
+  fn: ({ value }, context) => Effect.succeed(`${value.toUpperCase()}:${context.invocationCount}`),
+})
+
 const layer = (token = "test-token") =>
   Hatchet.layer({
-    tasks: [upper],
+    tasks: [upper, durableUpper],
     options: {
       client: { token: Redacted.make(token) },
       worker: { name: "test-worker" },
@@ -128,6 +138,16 @@ type CallbackDeclaration = {
   readonly fn: (
     input: unknown,
     taskContext: ReturnType<typeof context>,
+  ) => Promise<{ readonly value: string }>
+}
+
+type DurableCallbackDeclaration = {
+  readonly name: string
+  readonly fn: (
+    input: unknown,
+    taskContext: ReturnType<typeof context> & {
+      readonly invocationCount: number
+    },
   ) => Promise<{ readonly value: string }>
 }
 
@@ -219,7 +239,7 @@ describe("live SDK adapter behind Hatchet.layer", () => {
 
     expect(sdk.events.slice(0, 4)).toEqual([
       "worker",
-      "declarations:upper",
+      "declarations:upper,durable-upper",
       "start",
       "ready",
     ])
@@ -465,6 +485,151 @@ describe("live SDK adapter behind Hatchet.layer", () => {
       value: "CALLBACK",
     })
 
+    await runtime.dispose()
+  })
+
+  it("registers and dispatches durable declarations with invocation metadata", async () => {
+    const runtime = ManagedRuntime.make(layer())
+    await runtime.runPromise(Hatchet.runNoWait(upper, { value: "warm" }))
+
+    expect(sdk.durableTask).toHaveBeenCalledOnce()
+    const declaration = sdk.durableTask.mock
+      .calls[0]?.[0] as DurableCallbackDeclaration
+    await expect(
+      declaration.fn(
+        { value: "callback" },
+        {
+          ...context(),
+          invocationCount: 7,
+        },
+      ),
+    ).resolves.toEqual({ value: "CALLBACK:7" })
+
+    await runtime.dispose()
+  })
+
+  it("fails an unknown durable identity before SDK dispatch", async () => {
+    const unknown = Task.durable({
+      name: "unknown-durable",
+      fn: () => Effect.succeed("unreachable"),
+    })
+    const runtime = ManagedRuntime.make(layer())
+
+    await expect(
+      runtime.runPromise(Hatchet.runNoWait(unknown, undefined)),
+    ).rejects.toMatchObject({
+      _tag: "MissingTaskError",
+      taskName: "unknown-durable",
+    })
+    expect(sdk.runNoWait).not.toHaveBeenCalled()
+    await runtime.dispose()
+  })
+
+  it("reports durable input Schema failures without invoking the handler", async () => {
+    const runtime = ManagedRuntime.make(layer())
+    await runtime.runPromise(Hatchet.runNoWait(upper, { value: "warm" }))
+    const declaration = sdk.durableTask.mock
+      .calls[0]?.[0] as DurableCallbackDeclaration
+
+    await expect(
+      declaration.fn(
+        { value: 42 },
+        {
+          ...context(),
+          invocationCount: 2,
+        },
+      ),
+    ).rejects.toMatchObject({ message: "Hatchet task callback failed" })
+
+    await runtime.dispose()
+  })
+
+  it("interrupts durable callback execution from the SDK abort signal", async () => {
+    const interrupted = Task.durable({
+      name: "durable-interrupted",
+      fn: (_input: unknown, taskContext) => taskContext.interruption,
+    })
+    const runtime = ManagedRuntime.make(
+      Hatchet.layer({
+        tasks: [interrupted],
+        options: {
+          client: { token: Redacted.make("test-token") },
+          worker: { name: "test-worker" },
+        },
+      }),
+    )
+    await runtime.runPromise(Hatchet.runNoWait(interrupted, {}))
+    const declaration = sdk.durableTask.mock
+      .calls[0]?.[0] as DurableCallbackDeclaration
+    const controller = new AbortController()
+
+    const result = declaration.fn(
+      {},
+      {
+        ...context(controller),
+        invocationCount: 1,
+      },
+    )
+    controller.abort()
+
+    await expect(result).rejects.toMatchObject({
+      message: "Hatchet task callback failed",
+    })
+    await runtime.dispose()
+    expect(sdk.stop).toHaveBeenCalledOnce()
+  })
+
+  it("rejects duplicate declaration identities before SDK or worker mutation", async () => {
+    const duplicate = Task.make({
+      name: "upper",
+      fn: () => Effect.succeed("duplicate"),
+    })
+    const runtime = ManagedRuntime.make(
+      Hatchet.layer({
+        tasks: [upper, duplicate],
+        options: {
+          client: { token: Redacted.make("test-token") },
+          worker: { name: "test-worker" },
+        },
+      }),
+    )
+
+    await expect(
+      runtime.runPromise(Hatchet.runNoWait(upper, { value: "done" })),
+    ).rejects.toMatchObject({
+      _tag: "TaskDeclarationError",
+      taskName: "upper",
+      field: "name",
+      reason: "DuplicateIdentity",
+    })
+    expect(sdk.task).not.toHaveBeenCalled()
+    expect(sdk.durableTask).not.toHaveBeenCalled()
+    expect(sdk.worker).not.toHaveBeenCalled()
+    await runtime.dispose()
+  })
+
+  it("rejects an unknown declaration kind before SDK initialization", async () => {
+    const malformed = { ...upper, _tag: "Unknown" }
+    const invalidLayer = Reflect.apply(Hatchet.layer, undefined, [
+      {
+        tasks: [malformed],
+        options: {
+          client: { token: Redacted.make("test-token") },
+          worker: { name: "test-worker" },
+        },
+      },
+    ])
+    const runtime = ManagedRuntime.make(invalidLayer)
+
+    await expect(
+      runtime.runPromise(Hatchet.runNoWait(upper, { value: "done" })),
+    ).rejects.toMatchObject({
+      _tag: "TaskDeclarationError",
+      field: "_tag",
+      reason: "InvalidKind",
+    })
+    expect(sdk.init).not.toHaveBeenCalled()
+    expect(sdk.worker).not.toHaveBeenCalled()
     await runtime.dispose()
   })
 

--- a/packages/hatchet/tests/unit/public-api-source-contract.test.ts
+++ b/packages/hatchet/tests/unit/public-api-source-contract.test.ts
@@ -42,6 +42,9 @@ describe("public API source contract", () => {
     expect(api.Hatchet).not.toHaveProperty("register")
     expect(api.Hatchet).not.toHaveProperty("startWorker")
     expect(api.Hatchet).toHaveProperty("layer")
+    expect(api).toHaveProperty("RateLimit")
+    expect(api).toHaveProperty("Trigger")
+    expect(api).toHaveProperty("TaskDeclarationError")
     expect(api).not.toHaveProperty("HatchetRuntime")
   })
 

--- a/packages/hatchet/tests/unit/task-core.test.ts
+++ b/packages/hatchet/tests/unit/task-core.test.ts
@@ -4,10 +4,12 @@ import * as Context from "effect/Context"
 import * as Deferred from "effect/Deferred"
 import * as Effect from "effect/Effect"
 import * as Exit from "effect/Exit"
+import * as Fiber from "effect/Fiber"
 import * as Layer from "effect/Layer"
 import * as Option from "effect/Option"
 import * as Schema from "effect/Schema"
 import { Hatchet, Task } from "@effectify/hatchet"
+import { makeRunId } from "../../src/Model.js"
 
 class Prefix extends Context.Service<Prefix, { readonly value: string }>()(
   "@effectify/hatchet/test/Prefix",
@@ -69,6 +71,30 @@ describe("Task.make direct Effect execution", () => {
     await expect(Effect.runPromise(Effect.scoped(program))).resolves.toBe(
       "captured",
     )
+  })
+
+  it("dispatches a durable task through the in-memory registry exactly once", async () => {
+    let invocations = 0
+    const task = Task.durable({
+      name: "durable-local",
+      input: Schema.Struct({ value: Schema.Number }),
+      fn: ({ value }, context) =>
+        Effect.sync(() => {
+          invocations += 1
+          return `${value}:${context.invocationCount}`
+        }),
+    })
+
+    await expect(
+      Effect.runPromise(
+        Effect.scoped(
+          Hatchet.run(task, { value: 3 }).pipe(
+            Effect.provide(Hatchet.layerInMemory),
+          ),
+        ),
+      ),
+    ).resolves.toBe("3:0")
+    expect(invocations).toBe(1)
   })
 
   it("preserves typed failures and leaves defects in the defect channel", async () => {
@@ -186,6 +212,84 @@ describe("Schema input and output boundaries", () => {
 })
 
 describe("no-wait execution", () => {
+  it("releases a successful fire-and-forget run after completion", async () => {
+    const completed = Deferred.makeUnsafe<void>()
+    const task = Task.make({
+      name: "fire-and-forget-success",
+      fn: () => Deferred.succeed(completed, undefined),
+    })
+    const program = Effect.gen(function*() {
+      const handle = yield* Hatchet.runNoWait(task, undefined)
+      yield* Deferred.await(completed)
+      yield* Effect.yieldNow
+      return yield* Hatchet.cancelRun(handle.id).pipe(
+        Effect.catchTag("HatchetSdkError", Effect.succeed),
+      )
+    }).pipe(Effect.provide(Hatchet.layerInMemory))
+
+    await expect(
+      Effect.runPromise(Effect.scoped(program)),
+    ).resolves.toMatchObject({
+      _tag: "HatchetSdkError",
+      operation: "run.cancel",
+    })
+  })
+
+  it("releases a failed fire-and-forget run after completion", async () => {
+    const completed = Deferred.makeUnsafe<void>()
+    const task = Task.make({
+      name: "fire-and-forget-failure",
+      fn: () =>
+        Deferred.succeed(completed, undefined).pipe(
+          Effect.andThen(Effect.fail(new TypedFailure())),
+        ),
+    })
+    const program = Effect.gen(function*() {
+      const handle = yield* Hatchet.runNoWait(task, undefined)
+      yield* Deferred.await(completed)
+      yield* Effect.yieldNow
+      return yield* Hatchet.cancelRun(handle.id).pipe(
+        Effect.catchTag("HatchetSdkError", Effect.succeed),
+      )
+    }).pipe(Effect.provide(Hatchet.layerInMemory))
+
+    await expect(
+      Effect.runPromise(Effect.scoped(program)),
+    ).resolves.toMatchObject({
+      _tag: "HatchetSdkError",
+      operation: "run.cancel",
+    })
+  })
+
+  it("does not retain immediately interrupted submissions", async () => {
+    const task = Task.make({
+      name: "interrupted-submission",
+      fn: () => Effect.never,
+    })
+    const program = Effect.gen(function*() {
+      for (let index = 1; index <= 64; index += 1) {
+        const submission = yield* Effect.forkChild(
+          Hatchet.runNoWait(task, undefined),
+        )
+        yield* Fiber.interrupt(submission)
+      }
+      return yield* Effect.forEach(
+        Array.from({ length: 64 }, (_, index) => makeRunId(`run-${index + 1}`)),
+        (id) =>
+          Hatchet.cancelRun(id).pipe(
+            Effect.match({
+              onFailure: (error) => error._tag,
+              onSuccess: () => "retained" as const,
+            }),
+          ),
+      )
+    }).pipe(Effect.provide(Hatchet.layerInMemory))
+
+    await expect(
+      Effect.runPromise(Effect.scoped(program)),
+    ).resolves.not.toContain("retained")
+  })
+
   it("returns an observable handle whose cancellation interrupts work", async () => {
     const started = Deferred.makeUnsafe<void>()
     const task = Task.make({


### PR DESCRIPTION
Closes #70

## Summary

- Register ordinary and durable task declarations through the correct Hatchet SDK constructors.
- Dispatch durable tasks through one validated registry with invocation metadata and typed failures.
- Make in-memory no-wait registration interruption-safe and release completed runs automatically.

## PR Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Chain Context

This is PR2 of the Hatchet declarative task API Feature Branch Chain.

```text
feat/hatchet-v4-modernization (tracker PR #74)
└── feat/hatchet-declarative-task-api-contracts (PR1 #75)
    └── 📍 feat/hatchet-declarative-task-api-durable (PR2)
        └── PR3: exports, examples, and documentation
```

**Starts after:** PR1 declarative Task, RateLimit, and Trigger contracts  
**Ends with:** Durable registry, SDK registration, dispatch, typed failures, and lifecycle safety  
**Follow-up:** Root exports, examples, documentation, and final chain verification  
**Out of scope:** React Router examples, README changes, and final public API delivery

## Changes

| Area | Change |
|------|--------|
| Durable registry | Store and dispatch ordinary and durable task declarations |
| Live SDK adapter | Use `task` or `durableTask` according to declaration kind |
| Validation | Reject malformed and duplicate declarations before SDK mutation |
| In-memory runtime | Preserve invocation metadata and clean up interrupted/completed no-wait runs |
| Tests | Cover registration, dispatch, Schema failures, interruption, duplicates, and lifecycle cleanup |

## Test Plan

- [x] Hatchet tests: 132/132
- [x] Nx typecheck and production build
- [x] Nx lint
- [x] dprint
- [x] `git diff --check`
- [x] Final blind dual-judge review approved with empty ledgers

## Contributor Checklist

- [x] Linked approved issue #70
- [x] Added exactly one `type:*` label
- [x] Used conventional commits
- [x] Kept tests with implementation
- [x] Excluded PR3 scope
- [x] No `Co-Authored-By` trailers
