### PR TITLE
docs(hatchet): publish declarative task API

### DIFF
--- a/packages/hatchet/README.md
+++ b/packages/hatchet/README.md
@@ -36,6 +36,41 @@ const program = Hatchet.run(greet, { name: "Ada" }).pipe(
 
 `input` and `output` are optional Effect Schema codecs. Input is decoded before the task body; output is validated and encoded at the transport boundary. Boundary failures use `TaskSchemaError` with an `input` or `output` phase. Schema-free tasks remain supported.
 
+## Declarative metadata
+
+Package-owned `RateLimit` and `Trigger` values keep Hatchet SDK declaration types behind the adapter boundary. Values are immutable, validated before SDK or worker mutation, and translated without dropping duplicates or optional fields.
+
+```ts
+import { RateLimit, Task, Trigger } from "@effectify/hatchet"
+
+const notified = Task.make({
+  name: "customer-notified",
+  rateLimits: [RateLimit.make({ units: 10, duration: "minute", key: "customer" })],
+  triggers: [Trigger.event("customer:updated")],
+  fn: (input: { readonly customerId: string }) => Effect.succeed(input),
+})
+```
+
+Empty names, malformed rate limits or triggers, unknown declaration kinds, and duplicate task identities fail with `TaskDeclarationError` before registration starts.
+
+## Durable tasks
+
+`Task.durable` uses the same Effect-first Schema and requirements contract while exposing durable invocation metadata to the handler. The live adapter registers it with Hatchet's durable task API; the in-memory adapter supplies invocation count `0` for deterministic tests.
+
+```ts
+const durableGreeting = Task.durable({
+  name: "durable-greeting",
+  input: GreetingInput,
+  output: GreetingOutput,
+  fn: ({ name }, context) =>
+    Effect.succeed({
+      greeting: `Hello, ${name}! Invocation ${context.invocationCount}`,
+    }),
+})
+```
+
+Durable handlers receive `workflowRunId`, `taskRunExternalId`, `interruption`, and `invocationCount`. SDK abort signals interrupt the Effect execution, task requirements are captured when the Layer is acquired, and unknown task identities fail with `MissingTaskError` rather than dispatching another declaration.
+
 ## Dispatch without waiting
 
 `Hatchet.runNoWait(task, input)` dispatches the task and returns a scoped `RunHandle` before the task completes. Its branded `id` identifies the run, `await` produces the same Schema-decoded output as `Hatchet.run`, and `cancel` interrupts an outstanding run.
@@ -128,6 +163,9 @@ Omitting TLS strategy preserves the SDK secure default. Local plaintext Hatchet 
 ## Public API
 
 - `Task.make(options)` — declarative task identity with optional input/output Schema
+- `Task.durable(options)` — durable declaration with `Task.DurableContext`
+- `RateLimit.make(options)` — immutable rate-limit metadata
+- `Trigger.event(name)`, `Trigger.cron(expression)` — immutable trigger metadata
 - `Hatchet.layer({ tasks, options?, config? })` — package-owned lazy live Layer
 - `Hatchet.layerInMemory` — deterministic scoped adapter for tests
 - `Hatchet.run(task, input)` — await task output

--- a/packages/hatchet/src/index.ts
+++ b/packages/hatchet/src/index.ts
@@ -1,5 +1,7 @@
 export * as CronExpression from "./CronExpression.js"
 export * as Task from "./Task.js"
+export * as RateLimit from "./RateLimit.js"
+export * as Trigger from "./Trigger.js"
 export * as Hatchet from "./Hatchet.js"
 export * as HatchetConfig from "./HatchetConfig.js"
 export * from "./Error.js"

--- a/packages/hatchet/tests/types/declarative-task-api.ts
+++ b/packages/hatchet/tests/types/declarative-task-api.ts
@@ -1,7 +1,7 @@
 import * as Context from "effect/Context"
 import * as Effect from "effect/Effect"
 import * as Schema from "effect/Schema"
-import { Task } from "@effectify/hatchet"
+import { RateLimit, Task, TaskDeclarationError, Trigger } from "@effectify/hatchet"
 
 class Dependency extends Context.Service<
   Dependency,
@@ -27,9 +27,11 @@ const ordinary: Task.Task<"ordinary", Input, Output, Failure, Dependency> = Task
 
 const durable = Task.durable({
   name: "durable",
-  fn: (_input: Input, context) => {
+  fn: (_input: Input, context): Effect.Effect<Output, never, Dependency> => {
     const count: number = context.invocationCount
-    return Effect.succeed({ rendered: String(count) })
+    return Effect.map(Dependency, ({ value }) => ({
+      rendered: `${value}:${count}`,
+    }))
   },
 })
 
@@ -41,3 +43,10 @@ durable.execute({ value: 1 }, Task.DurableContext.empty).sleepFor
 ordinary.execute({ value: 1 }, Task.DurableContext.empty).invocationCount
 
 void mixed
+void RateLimit.make({ units: 1, duration: "minute" })
+void Trigger.event("customer:updated")
+void new TaskDeclarationError({
+  taskName: "ordinary",
+  field: "name",
+  reason: "DuplicateIdentity",
+})

--- a/packages/hatchet/tests/unit/public-api-source-contract.test.ts
+++ b/packages/hatchet/tests/unit/public-api-source-contract.test.ts
@@ -42,6 +42,9 @@ describe("public API source contract", () => {
     expect(api.Hatchet).not.toHaveProperty("register")
     expect(api.Hatchet).not.toHaveProperty("startWorker")
     expect(api.Hatchet).toHaveProperty("layer")
+    expect(api).toHaveProperty("RateLimit")
+    expect(api).toHaveProperty("Trigger")
+    expect(api).toHaveProperty("TaskDeclarationError")
     expect(api).not.toHaveProperty("HatchetRuntime")
   })
 


### PR DESCRIPTION
Closes #70

## Summary

- Export the declarative `RateLimit` and `Trigger` namespaces from the package root.
- Verify durable tasks, declaration errors, requirements, and metadata through consumer-facing type and runtime contracts.
- Document declarative metadata, durable context, validation behavior, and public API usage.

## PR Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Chain Context

This is PR3, the final slice of the Hatchet declarative task API Feature Branch Chain.

```text
feat/hatchet-v4-modernization (tracker PR #74)
└── feat/hatchet-declarative-task-api-contracts (PR1 #75)
    └── feat/hatchet-declarative-task-api-durable (PR2 #76)
        └── 📍 feat/hatchet-declarative-task-api-delivery (PR3)
```

**Starts after:** PR2 durable registry and dispatch  
**Ends with:** Root exports, consumer contracts, documentation, and final verification  
**Follow-up:** Integrate the reviewed chain through tracker PR #74  
**Out of scope:** Runtime implementation changes and React Router example changes

## Changes

| Area | Change |
|------|--------|
| Root API | Export `RateLimit` and `Trigger` namespaces |
| Type contract | Exercise durable requirements, metadata constructors, and typed declaration errors |
| Runtime contract | Assert supported root exports without leaking internal helpers |
| Documentation | Explain declarative metadata, durable tasks, validation, and lifecycle behavior |

## Test Plan

- [x] Public API contract RED then GREEN: 3/3
- [x] Hatchet suite: 132/132
- [x] Nx typecheck, lint, and production build
- [x] dprint
- [x] `git diff --check`
- [x] Blind dual Judgment Day approved with empty ledgers

## Contributor Checklist

- [x] Linked approved issue #70
- [x] Added exactly one `type:*` label
- [x] Used a conventional commit
- [x] Kept contracts with public API changes
- [x] Excluded runtime and React Router changes
- [x] No `Co-Authored-By` trailers
