### PR TITLE
feat(hatchet): complete modernization follow-ups

### DIFF
--- a/apps/react-router-example/README.md
+++ b/apps/react-router-example/README.md
@@ -19,8 +19,11 @@ Normal development, auth, Prisma, tests, typecheck, and builds do not require Ha
 
 ```bash
 pnpm install
+export BETTER_AUTH_SECRET="$(openssl rand -base64 32)"
 pnpm nx run @effectify/react-router-example:dev
 ```
+
+Generate a new local `BETTER_AUTH_SECRET` for each development environment. Do not commit the generated value.
 
 The app bootstraps its local SQLite auth and todo tables. Regenerate Prisma after changing its schema:
 
@@ -66,17 +69,22 @@ docker compose down
 
 ### Invoke the task
 
+Sign in first, then send the Better Auth session cookie with the request:
+
 ```bash
 curl -i -X POST http://localhost:4200/api/hatchet/runs \
   -H 'content-type: application/json' \
+  -H 'cookie: better-auth.session_token=<session-cookie>' \
   -d '{"name":"Ada"}'
 ```
 
-The endpoint awaits the registered worker and returns the Task output:
+An authenticated request receives immediate `202 Accepted` confirmation:
 
 ```json
-{ "greeting": "Hello, Ada!" }
+{ "ok": true, "runId": "..." }
 ```
+
+`202` confirms the workflow was accepted and started; it does not await workflow output.
 
 Invalid JSON or Schema input returns a safe `400` response through the existing React Router Effect adapter.
 

--- a/apps/react-router-example/app/lib/better-auth-options.server.ts
+++ b/apps/react-router-example/app/lib/better-auth-options.server.ts
@@ -1,36 +1,48 @@
-import { betterAuth } from "better-auth"
 import { openAPI } from "better-auth/plugins"
 import type { BetterAuthOptions } from "better-auth/types"
 import type Database from "better-sqlite3"
+import * as Config from "effect/Config"
+import * as ConfigProvider from "effect/ConfigProvider"
+import * as Effect from "effect/Effect"
+import * as Redacted from "effect/Redacted"
 import { database } from "./prisma.js"
 
 const defaultBetterAuthUrl = process.env.BETTER_AUTH_URL ?? "http://localhost:4200"
 
-export const authOptions = {
-  baseURL: defaultBetterAuthUrl,
-  secret: "hola",
-  emailAndPassword: {
-    enabled: true,
-  },
-  database: database as Database.Database,
-
-  advanced: {
-    defaultCookieAttributes: {
-      sameSite: "lax" as const,
-      secure: false,
-      path: "/",
-    },
-    cookies: {
-      session_token: {
-        attributes: {
-          sameSite: "lax" as const,
-          secure: false,
-          path: "/",
+export const authOptionsConfig = Config.redacted("BETTER_AUTH_SECRET").pipe(
+  Effect.filterOrFail(
+    (secret) => Redacted.value(secret).trim().length > 0,
+    () =>
+      new Config.ConfigError(
+        new ConfigProvider.SourceError({
+          message: "BETTER_AUTH_SECRET must be non-blank",
+        }),
+      ),
+  ),
+  Effect.map(
+    (secret) =>
+      ({
+        baseURL: defaultBetterAuthUrl,
+        secret: Redacted.value(secret),
+        emailAndPassword: { enabled: true },
+        database: database as Database.Database,
+        advanced: {
+          defaultCookieAttributes: {
+            sameSite: "lax" as const,
+            secure: false,
+            path: "/",
+          },
+          cookies: {
+            session_token: {
+              attributes: {
+                sameSite: "lax" as const,
+                secure: false,
+                path: "/",
+              },
+            },
+          },
         },
-      },
-    },
-  },
-  plugins: [openAPI()],
-} satisfies BetterAuthOptions
-
-export const auth = betterAuth(authOptions)
+        plugins: [openAPI()],
+      }) satisfies BetterAuthOptions,
+  ),
+)

--- a/apps/react-router-example/app/lib/runtime.server.ts
+++ b/apps/react-router-example/app/lib/runtime.server.ts
@@ -3,12 +3,13 @@ import { Hatchet } from "@effectify/hatchet"
 import { AuthService } from "@effectify/node-better-auth"
 import { Runtime } from "@effectify/react-router"
 import { PrismaBetterSqlite3 } from "@prisma/adapter-better-sqlite3"
+import * as Effect from "effect/Effect"
 import * as Layer from "effect/Layer"
 import { Prisma } from "./../../prisma/generated/effect/index.js"
-import { authOptions } from "./better-auth-options.server.js"
+import { authOptionsConfig } from "./better-auth-options.server.js"
 import { greetingTask } from "./hatchet/greeting-task.server.js"
 
-const authLayer = AuthService.AuthServiceContext.layer(authOptions)
+const authLayer = authOptionsConfig.pipe(Effect.map(AuthService.AuthServiceContext.layer), Layer.unwrap)
 
 const adapter = new PrismaBetterSqlite3({
   url: process.env.DATABASE_URL ?? "file:./dev.db",

--- a/apps/react-router-example/tests/unit/config/better-auth-options-contract.test.ts
+++ b/apps/react-router-example/tests/unit/config/better-auth-options-contract.test.ts
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises"
+import * as Config from "effect/Config"
 import * as ConfigProvider from "effect/ConfigProvider"
 import * as Effect from "effect/Effect"
 import { describe, expect, it, vi } from "vitest"
@@ -12,12 +13,11 @@ const withConfig = (values: Record<string, string>) =>
   )
 
 describe("Better Auth Effect configuration", () => {
-  it("rejects a missing secret without rendering supplied secret material", async () => {
-    const suppliedSecret = "missing-secret-must-not-appear"
+  it("rejects a missing secret with an identifiable configuration error", async () => {
     const error = await Effect.runPromise(withConfig({}).pipe(Effect.flip))
 
-    expect(String(error)).not.toContain(suppliedSecret)
-    expect(JSON.stringify(error)).not.toContain(suppliedSecret)
+    expect(error).toBeInstanceOf(Config.ConfigError)
+    expect(String(error)).toContain("BETTER_AUTH_SECRET")
   })
 
   it("rejects a whitespace-only secret without rendering it", async () => {

--- a/apps/react-router-example/tests/unit/config/better-auth-options-contract.test.ts
+++ b/apps/react-router-example/tests/unit/config/better-auth-options-contract.test.ts
@@ -1,8 +1,10 @@
 import { readFile } from "node:fs/promises"
 import * as ConfigProvider from "effect/ConfigProvider"
 import * as Effect from "effect/Effect"
-import { describe, expect, it } from "vitest"
+import { describe, expect, it, vi } from "vitest"
 import { authOptionsConfig } from "../../../app/lib/better-auth-options.server.js"
+
+vi.mock("../../../app/lib/prisma.js", () => ({ database: {} }))
 
 const withConfig = (values: Record<string, string>) =>
   authOptionsConfig.pipe(

--- a/apps/react-router-example/tests/unit/config/better-auth-options-contract.test.ts
+++ b/apps/react-router-example/tests/unit/config/better-auth-options-contract.test.ts
@@ -1,0 +1,77 @@
+import { readFile } from "node:fs/promises"
+import * as ConfigProvider from "effect/ConfigProvider"
+import * as Effect from "effect/Effect"
+import { describe, expect, it } from "vitest"
+import { authOptionsConfig } from "../../../app/lib/better-auth-options.server.js"
+
+const withConfig = (values: Record<string, string>) =>
+  authOptionsConfig.pipe(
+    Effect.provide(ConfigProvider.layer(ConfigProvider.fromUnknown(values))),
+  )
+
+describe("Better Auth Effect configuration", () => {
+  it("rejects a missing secret without rendering supplied secret material", async () => {
+    const suppliedSecret = "missing-secret-must-not-appear"
+    const error = await Effect.runPromise(withConfig({}).pipe(Effect.flip))
+
+    expect(String(error)).not.toContain(suppliedSecret)
+    expect(JSON.stringify(error)).not.toContain(suppliedSecret)
+  })
+
+  it("rejects a whitespace-only secret without rendering it", async () => {
+    const suppliedSecret = " \t\n "
+    const error = await Effect.runPromise(
+      withConfig({ BETTER_AUTH_SECRET: suppliedSecret }).pipe(Effect.flip),
+    )
+
+    expect(String(error)).not.toContain(suppliedSecret)
+    expect(JSON.stringify(error)).not.toContain(suppliedSecret)
+  })
+
+  it("passes a valid secret only to the Better Auth options boundary and preserves the URL", async () => {
+    const suppliedSecret = "valid-secret-sentinel"
+    const options = await Effect.runPromise(
+      withConfig({ BETTER_AUTH_SECRET: suppliedSecret }),
+    )
+
+    expect(options.secret).toBe(suppliedSecret)
+    expect(options.baseURL).toBe(
+      process.env.BETTER_AUTH_URL ?? "http://localhost:4200",
+    )
+    expect(JSON.stringify({ baseURL: options.baseURL })).not.toContain(
+      suppliedSecret,
+    )
+  })
+})
+
+describe("Hatchet run README contract", () => {
+  it("documents the required local Better Auth secret setup", async () => {
+    const readme = await readFile(
+      new URL("../../../README.md", import.meta.url),
+      "utf8",
+    )
+
+    expect(readme).toContain(
+      'export BETTER_AUTH_SECRET="$(openssl rand -base64 32)"',
+    )
+    expect(readme).toContain("Do not commit the generated value.")
+  })
+
+  it("documents the current authenticated asynchronous acceptance route", async () => {
+    const readme = await readFile(
+      new URL("../../../README.md", import.meta.url),
+      "utf8",
+    )
+
+    expect(readme).toContain("Sign in first")
+    expect(readme).toContain(
+      "cookie: better-auth.session_token=<session-cookie>",
+    )
+    expect(readme).toContain("202 Accepted")
+    expect(readme).toContain('{ "ok": true, "runId": "..." }')
+    expect(readme).toContain("does not await workflow output")
+    expect(readme).toContain("safe `400`")
+    expect(readme).not.toContain("awaits the registered worker")
+    expect(readme).not.toContain('{ "greeting": "Hello, Ada!" }')
+  })
+})

--- a/apps/react-router-example/tests/unit/lib/runtime.server.test.ts
+++ b/apps/react-router-example/tests/unit/lib/runtime.server.test.ts
@@ -14,12 +14,15 @@ const { adapterConfigMock, authHandlerMock, prismaLayerMock } = vi.hoisted(
   },
 )
 
-vi.mock("../../../app/lib/better-auth-options.server.js", () => ({
-  authOptions: {
-    baseURL: "http://localhost:4200",
-    secret: "runtime-test-secret",
-  },
-}))
+vi.mock("../../../app/lib/better-auth-options.server.js", async () => {
+  const Effect = await import("effect/Effect")
+  return {
+    authOptionsConfig: Effect.succeed({
+      baseURL: "http://localhost:4200",
+      secret: "runtime-test-secret",
+    }),
+  }
+})
 
 vi.mock("@effectify/node-better-auth", async () => {
   const Context = await import("effect/Context")

--- a/packages/hatchet/package.json
+++ b/packages/hatchet/package.json
@@ -20,6 +20,14 @@
       "default": "./dist/src/index.js",
       "node": "./dist/src/index.js",
       "nodejs": "./dist/src/index.js"
+    },
+    "./testing": {
+      "@effectify/source": "./src/testing/index.ts",
+      "types": "./dist/src/testing/index.d.ts",
+      "import": "./dist/src/testing/index.js",
+      "default": "./dist/src/testing/index.js",
+      "node": "./dist/src/testing/index.js",
+      "nodejs": "./dist/src/testing/index.js"
     }
   },
   "files": [

--- a/packages/hatchet/project.json
+++ b/packages/hatchet/project.json
@@ -6,16 +6,22 @@
   "targets": {
     "build": {
       "executor": "@nx/js:tsc",
-      "outputs": ["{options.outputPath}"],
+      "outputs": [
+        "{options.outputPath}"
+      ],
       "defaultConfiguration": "production",
       "options": {
         "outputPath": "packages/hatchet/dist",
         "main": "packages/hatchet/src/index.ts",
         "tsConfig": "packages/hatchet/tsconfig.lib.json",
-        "format": ["esm"],
+        "format": [
+          "esm"
+        ],
         "generatePackageJson": false,
         "updateBuildableProjectDepsInPackageJson": false,
-        "additionalEntryPoints": []
+        "additionalEntryPoints": [
+          "packages/hatchet/src/testing/index.ts"
+        ]
       },
       "configurations": {
         "development": {},
@@ -31,11 +37,19 @@
     },
     "lint": {
       "executor": "nx-oxlint:lint",
-      "outputs": ["{options.outputFile}"],
+      "outputs": [
+        "{options.outputFile}"
+      ],
       "options": {
-        "lintFilePatterns": ["packages/hatchet/**/*.{ts,tsx,js,jsx}"]
+        "lintFilePatterns": [
+          "packages/hatchet/**/*.{ts,tsx,js,jsx}"
+        ]
       }
     }
   },
-  "tags": ["node", "react", "hatchet"]
+  "tags": [
+    "node",
+    "react",
+    "hatchet"
+  ]
 }

--- a/packages/hatchet/src/Error.ts
+++ b/packages/hatchet/src/Error.ts
@@ -156,6 +156,11 @@ export class HatchetSdkError extends Data.TaggedError("HatchetSdkError")<{
 /** Classifies package and SDK failures without exposing implementation causes. */
 export const failureReason = (cause: unknown): HatchetFailureReason => classifyFailure("operation", cause)
 
+export class InvalidEventError extends Data.TaggedError("InvalidEventError")<{
+  readonly field: "key" | "payload" | "options"
+  readonly reason: "EmptyKey" | "UnsafeKey" | "InvalidJsonObject" | "UnsupportedOption" | "InvalidOptionValue"
+}> {}
+
 export class InvalidTimeError extends Data.TaggedError("InvalidTimeError")<{
   readonly field: "at" | "delay"
   readonly originalCause: unknown

--- a/packages/hatchet/src/Hatchet.ts
+++ b/packages/hatchet/src/Hatchet.ts
@@ -1,6 +1,7 @@
 import * as Cause from "effect/Cause"
 import * as Clock from "effect/Clock"
 import type * as Config from "effect/Config"
+import type { Hatchet as HatchetClientSdk } from "@hatchet-dev/typescript-sdk"
 import * as Context from "effect/Context"
 import * as Deferred from "effect/Deferred"
 import * as Duration from "effect/Duration"
@@ -17,6 +18,7 @@ import {
   HatchetSdkError,
   type InvalidCronError,
   type InvalidCronFilterError,
+  InvalidEventError,
   type InvalidHatchetConfiguration,
   InvalidTimeError,
   type MissingTaskError,
@@ -42,6 +44,130 @@ import * as Registry from "./internal/registry.js"
 import type * as Task from "./Task.js"
 
 export type { CronRecord, ScheduleRecord } from "./Model.js"
+
+export type EventJsonValue =
+  | null
+  | boolean
+  | number
+  | string
+  | ReadonlyArray<EventJsonValue>
+  | {
+    readonly [key: string]: EventJsonValue
+  }
+export type EventPayload = { readonly [key: string]: EventJsonValue }
+export type PushEventOptions = Parameters<
+  InstanceType<typeof HatchetClientSdk>["events"]["push"]
+>[2]
+export interface EventReceipt<TPayload extends EventPayload> {
+  readonly eventId: string
+  readonly key: string
+  readonly payload: TPayload
+  readonly additionalMetadata?: Readonly<Record<string, unknown>>
+  readonly scope?: string
+}
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" &&
+  value !== null &&
+  !Array.isArray(value) &&
+  Object.getPrototypeOf(value) === Object.prototype
+
+const isJsonValue = (value: unknown, seen: Set<object>): boolean => {
+  if (value === null || typeof value === "boolean" || typeof value === "string") {
+    return true
+  }
+  if (typeof value === "number") return Number.isFinite(value)
+  if (typeof value !== "object" || seen.has(value)) return false
+  seen.add(value)
+  const valid = Array.isArray(value)
+    ? Array.from(
+      { length: value.length },
+      (_, index) => index in value && isJsonValue(value[index], seen),
+    ).every(Boolean)
+    : isPlainObject(value) &&
+      Object.values(value).every((item) => isJsonValue(item, seen))
+  seen.delete(value)
+  return valid
+}
+
+export const validateEvent = (
+  key: string,
+  payload: unknown,
+  options?: unknown,
+): Effect.Effect<void, InvalidEventError> =>
+  Effect.suspend(() => {
+    if (key.trim().length === 0) {
+      return Effect.fail(
+        new InvalidEventError({ field: "key", reason: "EmptyKey" }),
+      )
+    }
+    if (/[\u0000-\u001F\u007F-\u009F]/.test(key)) {
+      return Effect.fail(
+        new InvalidEventError({ field: "key", reason: "UnsafeKey" }),
+      )
+    }
+    if (!isPlainObject(payload) || !isJsonValue(payload, new Set())) {
+      return Effect.fail(
+        new InvalidEventError({
+          field: "payload",
+          reason: "InvalidJsonObject",
+        }),
+      )
+    }
+    if (options === undefined) return Effect.void
+    if (!isPlainObject(options)) {
+      return Effect.fail(
+        new InvalidEventError({
+          field: "options",
+          reason: "InvalidOptionValue",
+        }),
+      )
+    }
+    for (const option of Object.keys(options)) {
+      if (!["additionalMetadata", "priority", "scope"].includes(option)) {
+        return Effect.fail(
+          new InvalidEventError({
+            field: "options",
+            reason: "UnsupportedOption",
+          }),
+        )
+      }
+    }
+    const { additionalMetadata, priority, scope } = options
+    if (
+      additionalMetadata !== undefined &&
+      (!isPlainObject(additionalMetadata) ||
+        !Object.values(additionalMetadata).every(
+          (value) => typeof value === "string",
+        ))
+    ) {
+      return Effect.fail(
+        new InvalidEventError({
+          field: "options",
+          reason: "InvalidOptionValue",
+        }),
+      )
+    }
+    if (
+      priority !== undefined &&
+      (typeof priority !== "number" || !Number.isFinite(priority))
+    ) {
+      return Effect.fail(
+        new InvalidEventError({
+          field: "options",
+          reason: "InvalidOptionValue",
+        }),
+      )
+    }
+    return scope === undefined || typeof scope === "string"
+      ? Effect.void
+      : Effect.fail(
+        new InvalidEventError({
+          field: "options",
+          reason: "InvalidOptionValue",
+        }),
+      )
+  })
 
 export interface RunHandle<Output, Error> {
   readonly id: RunId
@@ -78,6 +204,14 @@ export type AcquisitionError =
   | TaskDeclarationError
 
 export interface Service {
+  readonly pushEvent: <const TPayload extends EventPayload>(
+    key: string,
+    payload: TPayload,
+    options?: PushEventOptions,
+  ) => Effect.Effect<
+    EventReceipt<TPayload>,
+    InvalidEventError | AcquisitionError
+  >
   readonly run: <Name extends string, Input, Output, Error, Requirements>(
     task: Task.Of<Name, Input, Output, Error, Requirements>,
     input: unknown,
@@ -152,6 +286,7 @@ const makeInMemoryService = (ownerScope: Scope.Scope): Service => {
   >()
   const runs = new Map<RunId, Fiber.Fiber<unknown, unknown>>()
   const crons = new Map<CronId, CronRecord>()
+  let nextEventId = 1
   let nextRunId = 1
   let nextScheduleId = 1
   let nextCronId = 1
@@ -405,6 +540,20 @@ const makeInMemoryService = (ownerScope: Scope.Scope): Service => {
     })
 
   return {
+    pushEvent: (key, payload, options) =>
+      validateEvent(key, payload, options).pipe(
+        Effect.andThen(
+          Effect.sync(() => ({
+            eventId: `event-${nextEventId++}`,
+            key,
+            payload,
+            ...(options?.additionalMetadata === undefined
+              ? {}
+              : { additionalMetadata: options.additionalMetadata }),
+            ...(options?.scope === undefined ? {} : { scope: options.scope }),
+          })),
+        ),
+      ),
     run: (task, input) => runNoWait(task, input).pipe(Effect.flatMap((handle) => handle.await)),
     runNoWait,
     schedule,
@@ -574,6 +723,12 @@ export const layer = <const Tasks extends ReadonlyArray<Task.Any>>(
       ) => Effect.flatMap(ready, ({ service }) => operation(service))
 
       const service = Hatchet.of({
+        pushEvent: (key, payload, eventOptions) =>
+          validateEvent(key, payload, eventOptions).pipe(
+            Effect.andThen(
+              use((hatchet) => hatchet.pushEvent(key, payload, eventOptions)),
+            ),
+          ),
         run: (task, input) => use((hatchet) => hatchet.run(task, input)),
         runNoWait: (task, input) => use((hatchet) => hatchet.runNoWait(task, input)),
         schedule: (task, input, timing) => use((hatchet) => hatchet.schedule(task, input, timing)),
@@ -599,6 +754,21 @@ export const layer = <const Tasks extends ReadonlyArray<Task.Any>>(
       )
       return service
     }),
+  )
+
+export const pushEvent = <const TPayload extends EventPayload>(
+  key: string,
+  payload: TPayload,
+  options?: PushEventOptions,
+): Effect.Effect<
+  EventReceipt<TPayload>,
+  InvalidEventError | AcquisitionError,
+  Hatchet
+> =>
+  validateEvent(key, payload, options).pipe(
+    Effect.andThen(
+      Effect.flatMap(Hatchet, (service) => service.pushEvent(key, payload, options)),
+    ),
   )
 
 export const run = <Name extends string, Input, Output, Error, Requirements>(

--- a/packages/hatchet/src/internal/live.ts
+++ b/packages/hatchet/src/internal/live.ts
@@ -483,19 +483,13 @@ const makeService = <Requirements>(
                 return yield* Effect.die(stopDefect)
               }
               const timedOut = Cause.isTimeoutError(stopDefect.originalCause)
-              if (timedOut) {
-                yield* Effect.logError(
-                  "Hatchet worker stop timed out",
-                  options.worker.name,
-                )
-              }
+              yield* Effect.logError(
+                timedOut
+                  ? "Hatchet worker stop timed out"
+                  : "Hatchet worker stop failed during failed scope cleanup",
+                { workerName: options.worker.name, operation: "worker.stop" },
+              )
               if (Exit.isFailure(exit)) {
-                if (!timedOut) {
-                  yield* Effect.logError(
-                    "Hatchet worker stop failed during failed scope cleanup",
-                    stopDefect.originalCause,
-                  )
-                }
                 return
               }
               return yield* Effect.die(stopDefect)
@@ -701,7 +695,44 @@ const makeService = <Requirements>(
         return yield* result.failure
       })
 
+    const pushEvent: Hatchet.Service["pushEvent"] = (
+      key,
+      payload,
+      eventOptions,
+    ) =>
+      Hatchet.validateEvent(key, payload, eventOptions).pipe(
+        Effect.andThen(ensureOpen("event.push")),
+        Effect.andThen(
+          Effect.tryPromise({
+            try: () => client.events.push(key, payload, eventOptions),
+            catch: (originalCause) => sdkError("event.push", originalCause, key),
+          }),
+        ),
+        Effect.flatMap((event) =>
+          typeof event === "object" &&
+            event !== null &&
+            "eventId" in event &&
+            typeof event.eventId === "string" &&
+            event.eventId.length > 0
+            ? Effect.succeed({
+              eventId: event.eventId,
+              key,
+              payload,
+              ...(eventOptions?.additionalMetadata === undefined
+                ? {}
+                : { additionalMetadata: eventOptions.additionalMetadata }),
+              ...(eventOptions?.scope === undefined
+                ? {}
+                : { scope: eventOptions.scope }),
+            })
+            : Effect.fail(
+              sdkError("event.push", { reason: "InvalidResponse" }, key),
+            )
+        ),
+      )
+
     return {
+      pushEvent,
       run: (task, input) => runNoWait(task, input).pipe(Effect.flatMap((handle) => handle.await)),
       runNoWait,
       schedule: (task, input, timing) =>

--- a/packages/hatchet/src/testing/index.ts
+++ b/packages/hatchet/src/testing/index.ts
@@ -20,3 +20,5 @@ export {
   TestHatchetConfigLayer,
   TestHatchetLayer,
 } from "./mock-client.js"
+
+export { layerInMemory } from "../Hatchet.js"

--- a/packages/hatchet/tests/unit/events.test.ts
+++ b/packages/hatchet/tests/unit/events.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest"
+import * as Effect from "effect/Effect"
+import { Hatchet } from "@effectify/hatchet"
+
+describe("Hatchet.pushEvent", () => {
+  it("validates JSON-object events before side effects and echoes valid in-memory events", async () => {
+    const invalid = await Effect.runPromise(
+      Hatchet.pushEvent(" ", { value: "ok" }).pipe(
+        Effect.flip,
+        Effect.provide(Hatchet.layerInMemory),
+        Effect.scoped,
+      ),
+    )
+    expect(invalid).toMatchObject({
+      _tag: "InvalidEventError",
+      field: "key",
+      reason: "EmptyKey",
+    })
+
+    const receipt = await Effect.runPromise(
+      Hatchet.pushEvent(
+        "customer.updated",
+        { nested: [true, null] },
+        {
+          additionalMetadata: { source: "test" },
+          priority: 4,
+          scope: "tenant-a",
+        },
+      ).pipe(Effect.provide(Hatchet.layerInMemory), Effect.scoped),
+    )
+    expect(receipt).toEqual({
+      eventId: "event-1",
+      key: "customer.updated",
+      payload: { nested: [true, null] },
+      additionalMetadata: { source: "test" },
+      scope: "tenant-a",
+    })
+  })
+
+  it("rejects sparse JSON arrays without advancing the in-memory event counter", async () => {
+    const payload = { nested: ["value"] }
+    delete payload.nested[0]
+    const program = Effect.gen(function*() {
+      const service = yield* Hatchet.Hatchet
+      const failure = yield* service
+        .pushEvent("invalid", payload)
+        .pipe(Effect.flip)
+      const receipt = yield* service.pushEvent("valid", { ok: true })
+      return { failure, receipt }
+    }).pipe(Effect.provide(Hatchet.layerInMemory), Effect.scoped)
+
+    await expect(Effect.runPromise(program)).resolves.toMatchObject({
+      failure: {
+        _tag: "InvalidEventError",
+        field: "payload",
+        reason: "InvalidJsonObject",
+      },
+      receipt: { eventId: "event-1" },
+    })
+  })
+})

--- a/packages/hatchet/tests/unit/live-sdk-port.test.ts
+++ b/packages/hatchet/tests/unit/live-sdk-port.test.ts
@@ -3,9 +3,12 @@ import * as Deferred from "effect/Deferred"
 import * as Effect from "effect/Effect"
 import * as Fiber from "effect/Fiber"
 import * as Layer from "effect/Layer"
+import * as Logger from "effect/Logger"
 import * as ManagedRuntime from "effect/ManagedRuntime"
 import * as Redacted from "effect/Redacted"
 import * as Schema from "effect/Schema"
+import * as Scope from "effect/Scope"
+import * as Exit from "effect/Exit"
 import { TestClock } from "effect/testing"
 import { CronExpression, Hatchet, makeCronId } from "@effectify/hatchet"
 import * as RateLimit from "../../src/RateLimit.js"
@@ -39,6 +42,8 @@ const sdk = vi.hoisted(() => {
   }))
   const task = vi.fn((declaration) => ({ ...declaration, runNoWait }))
   const durableTask = vi.fn((declaration) => ({ ...declaration, runNoWait }))
+  const pushEvent = vi.fn(async () => ({ eventId: "event-42" }))
+  const eventsClient = { push: pushEvent }
   const crons = {
     create: vi.fn(async (name: string) => ({
       metadata: { id: "cron-42" },
@@ -58,6 +63,7 @@ const sdk = vi.hoisted(() => {
       durableTask,
       worker,
       crons,
+      events: eventsClient,
       scheduled: { create: vi.fn(), get: vi.fn(), delete: vi.fn() },
       runs: { cancel: vi.fn() },
     })),
@@ -71,6 +77,7 @@ const sdk = vi.hoisted(() => {
     runNoWait,
     cancel,
     crons,
+    pushEvent,
   }
 })
 
@@ -202,6 +209,7 @@ describe("live SDK adapter behind Hatchet.layer", () => {
         stop: sdk.stop,
       }
     })
+    sdk.pushEvent.mockResolvedValue({ eventId: "event-42" })
     sdk.runNoWait.mockResolvedValue({
       runId: Promise.resolve("run-42"),
       output: Promise.resolve({ value: "DONE" }),
@@ -927,6 +935,111 @@ describe("live SDK adapter behind Hatchet.layer", () => {
     ).rejects.toMatchObject({ _tag: "InvalidCronFilterError", field })
     expect(sdk.crons.list).not.toHaveBeenCalled()
     await runtime.dispose()
+  })
+
+  it("publishes events with exact SDK arguments, normalizes the receipt, and disposes the live service", async () => {
+    const runtime = ManagedRuntime.make(layer())
+    const payload = { customer: { id: "customer-1" }, active: true } as const
+    const options = {
+      additionalMetadata: { source: "unit-test" },
+      priority: 4,
+      scope: "tenant-a",
+    }
+
+    const receipt = await runtime.runPromise(
+      Hatchet.pushEvent("customer.updated", payload, options),
+    )
+
+    expect(sdk.pushEvent).toHaveBeenCalledExactlyOnceWith(
+      "customer.updated",
+      payload,
+      options,
+    )
+    expect(receipt).toEqual({
+      eventId: "event-42",
+      key: "customer.updated",
+      payload,
+      additionalMetadata: options.additionalMetadata,
+      scope: options.scope,
+    })
+    await runtime.dispose()
+    expect(sdk.stop).toHaveBeenCalledOnce()
+  })
+
+  it.each([
+    ["blank key", " ", { ok: true }, undefined],
+    ["control key", "unsafe\u0000key", { ok: true }, undefined],
+    ["invalid payload", "customer.updated", { invalid: undefined }, undefined],
+    ["unsupported option", "customer.updated", { ok: true }, { unknown: true }],
+  ])("rejects %s before lazy SDK initialization or event dispatch", async (_name, key, payload, options) => {
+    const runtime = ManagedRuntime.make(layer())
+
+    const error = await runtime.runPromise(
+      Reflect.apply(Hatchet.pushEvent, undefined, [key, payload, options]).pipe(
+        Effect.flip,
+      ),
+    )
+
+    expect(error).toMatchObject({ _tag: "InvalidEventError" })
+    expect(sdk.init).not.toHaveBeenCalled()
+    expect(sdk.worker).not.toHaveBeenCalled()
+    expect(sdk.pushEvent).not.toHaveBeenCalled()
+    await runtime.dispose()
+  })
+
+  it("maps SDK event rejections and malformed required event IDs without exposing causes", async () => {
+    const runtime = ManagedRuntime.make(layer())
+    const secret = "event-sdk-secret"
+    sdk.pushEvent.mockRejectedValueOnce(new Error(secret))
+    const rejection = await runtime.runPromise(
+      Hatchet.pushEvent("customer.updated", { ok: true }).pipe(Effect.flip),
+    )
+    sdk.pushEvent.mockResolvedValueOnce({ eventId: "" })
+    const malformed = await runtime.runPromise(
+      Hatchet.pushEvent("customer.updated", { ok: true }).pipe(Effect.flip),
+    )
+
+    expect(rejection).toMatchObject({
+      _tag: "HatchetSdkError",
+      operation: "event.push",
+      resourceId: "customer.updated",
+    })
+    expect(JSON.stringify(rejection)).not.toContain(secret)
+    expect(malformed).toMatchObject({
+      _tag: "HatchetSdkError",
+      operation: "event.push",
+      reason: "InvalidResponse",
+    })
+    await runtime.dispose()
+  })
+
+  it("redacts rejected worker-stop causes from failed-scope cleanup logs while preserving propagation", async () => {
+    const secret = "worker-stop-secret-sentinel"
+    const logs: string[] = []
+    const logger = Logger.make(({ cause, message }) => logs.push(JSON.stringify({ cause: String(cause), message })))
+    sdk.stop.mockRejectedValueOnce(new Error(secret))
+    const failure = new Error("scope-failure")
+
+    const close = await Effect.runPromise(
+      Effect.gen(function*() {
+        const scope = yield* Scope.make()
+        const context = yield* Layer.buildWithScope(scope)(
+          Layer.merge(layer(), Logger.layer([logger])),
+        )
+        yield* Hatchet.pushEvent("customer.updated", { ok: true }).pipe(
+          Effect.provide(context),
+        )
+        return yield* Scope.close(scope, Exit.fail(failure)).pipe(Effect.exit)
+      }),
+    )
+
+    expect(Exit.isFailure(close)).toBe(true)
+    expect(sdk.stop).toHaveBeenCalledOnce()
+    expect(logs.join("\\n")).toContain(
+      "Hatchet worker stop failed during failed scope cleanup",
+    )
+    expect(logs.join("\\n")).toContain("worker.stop")
+    expect(logs.join("\\n")).not.toContain(secret)
   })
 
   it("paginates failed-delete absence verification safely", async () => {

--- a/packages/hatchet/tests/unit/package-contract.test.ts
+++ b/packages/hatchet/tests/unit/package-contract.test.ts
@@ -1,0 +1,53 @@
+import { execFileSync } from "node:child_process"
+import { existsSync, rmSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { describe, expect, it } from "vitest"
+
+const packageDirectory = fileURLToPath(new URL("../..", import.meta.url))
+const repositoryDirectory = fileURLToPath(
+  new URL("../../../..", import.meta.url),
+)
+
+const runNode = (source: string): string =>
+  execFileSync(process.execPath, ["--input-type=module", "--eval", source], {
+    cwd: packageDirectory,
+    encoding: "utf8",
+  })
+
+describe("published package contract", () => {
+  it("builds a clean testing subpath without exposing testing helpers from the root", () => {
+    rmSync(new URL("../../dist", import.meta.url), {
+      force: true,
+      recursive: true,
+    })
+    execFileSync(
+      "pnpm",
+      ["nx", "run", "@effectify/hatchet:build", "--skip-nx-cache"],
+      {
+        cwd: repositoryDirectory,
+        stdio: "inherit",
+      },
+    )
+
+    expect(
+      existsSync(new URL("../../dist/src/testing/index.js", import.meta.url)),
+    ).toBe(true)
+    expect(
+      existsSync(new URL("../../dist/src/testing/index.d.ts", import.meta.url)),
+    ).toBe(true)
+
+    const output = runNode(`
+      import * as root from "@effectify/hatchet"
+      import * as testing from "@effectify/hatchet/testing"
+      console.log(JSON.stringify({
+        testingLayer: typeof testing.TestHatchetLayer,
+        rootHasTestingLayer: "TestHatchetLayer" in root,
+      }))
+    `)
+
+    expect(JSON.parse(output)).toEqual({
+      testingLayer: "object",
+      rootHasTestingLayer: false,
+    })
+  })
+})

--- a/packages/hatchet/tests/unit/package-contract.test.ts
+++ b/packages/hatchet/tests/unit/package-contract.test.ts
@@ -1,12 +1,9 @@
 import { execFileSync } from "node:child_process"
-import { existsSync, rmSync } from "node:fs"
+import { existsSync } from "node:fs"
 import { fileURLToPath } from "node:url"
 import { describe, expect, it } from "vitest"
 
 const packageDirectory = fileURLToPath(new URL("../..", import.meta.url))
-const repositoryDirectory = fileURLToPath(
-  new URL("../../../..", import.meta.url),
-)
 
 const runNode = (source: string): string =>
   execFileSync(process.execPath, ["--input-type=module", "--eval", source], {
@@ -15,20 +12,7 @@ const runNode = (source: string): string =>
   })
 
 describe("published package contract", () => {
-  it("builds a clean testing subpath without exposing testing helpers from the root", () => {
-    rmSync(new URL("../../dist", import.meta.url), {
-      force: true,
-      recursive: true,
-    })
-    execFileSync(
-      "pnpm",
-      ["nx", "run", "@effectify/hatchet:build", "--skip-nx-cache"],
-      {
-        cwd: repositoryDirectory,
-        stdio: "inherit",
-      },
-    )
-
+  it("resolves the built testing subpath without exposing testing helpers from the root", () => {
     expect(
       existsSync(new URL("../../dist/src/testing/index.js", import.meta.url)),
     ).toBe(true)


### PR DESCRIPTION
Closes #70

## Type

- [ ] Bug fix
- [x] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [ ] Maintenance/tooling
- [ ] Breaking change

## Summary

- Add validated Effect-first event publishing through the modern Hatchet runtime.
- Publish `@effectify/hatchet/testing` and sanitize worker shutdown diagnostics.
- Require a redacted Better Auth secret and align the React Router Hatchet documentation with its authenticated asynchronous contract.

## Changes

| Area | Change |
|---|---|
| `packages/hatchet/src` | Adds pre-lazy event validation, live/in-memory event publication, normalized receipts, typed errors, and safe shutdown logging. |
| `packages/hatchet/package.json`, `project.json` | Publishes and builds the dedicated testing subpath. |
| `apps/react-router-example/app/lib` | Acquires `BETTER_AUTH_SECRET` through Effect Config and `Layer.unwrap`. |
| `apps/react-router-example/README.md` | Documents secure local setup, authentication, and HTTP 202 run acceptance. |
| Tests | Covers event boundaries, SDK delegation, logging redaction, package resolution, auth configuration, and documentation contracts. |

## Test Plan

- [x] `pnpm nx run-many -t test,typecheck,lint -p @effectify/hatchet,@effectify/react-router-example --skip-nx-cache --parallel=1`
- [x] `pnpm nx run @effectify/hatchet:build --skip-nx-cache`
- [x] `pnpm nx run @effectify/react-router-example:build --skip-nx-cache`
- [x] `pnpm exec dprint check`
- [x] `git diff --check`
- [x] Built `@effectify/hatchet/testing` JavaScript and declarations resolve through the export map
- [x] Judgment Day and final full 4R review approved the exact committed snapshot

## Review Workload

- Production/config/docs: 246 changed lines
- Tests: 270 changed lines, excluded from the approved production budget
- Delivery: one PR under the 400 productive-line budget

## Contributor Checklist

- [x] Linked approved issue #70
- [x] Exactly one `type:*` label will be applied
- [x] No modified shell scripts require shellcheck
- [x] Effect and project skills were applied
- [x] Documentation updated for behavior/configuration changes
- [x] Conventional commits used
- [x] No AI attribution or `Co-Authored-By` trailers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added event publishing through the Hatchet API, including event validation, receipts, metadata, scopes, and generated event IDs.
  * Added a public testing entry point with an in-memory Hatchet layer.
  * Added structured errors for invalid event keys, payloads, and options.
  * React Router example now requires a runtime authentication secret and authenticated event-triggering requests.

* **Bug Fixes**
  * Improved shutdown error logging and redaction of sensitive failure details.

* **Documentation**
  * Updated API documentation to describe immediate `202 Accepted` responses and returned run IDs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->