### PR TITLE
chore(docs): refresh Effect and Alchemy references

### DIFF
--- a/.agent/skills/effect-context-manager/SKILL.md
+++ b/.agent/skills/effect-context-manager/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: effect-context-manager
 description: >
-  Gestiona el entorno de referencia de Effect v4 alojado en el worktree ./effect-reference.
-  Trigger: Cuando se necesita consultar código de effect-smol, actualizar el contexto, o configurar en nueva máquina.
+  Gestiona los clones locales de referencia de Effect v4 y Alchemy alojados en ./.effect-reference.
+  Trigger: Cuando se necesita consultar el código de Effect o Alchemy, actualizar el contexto, o configurar una nueva máquina.
 license: Apache-2.0
 metadata:
   author: gentleman-programming
@@ -11,90 +11,116 @@ metadata:
 
 ## When to Use
 
-- Clonar el proyecto en una nueva máquina y montar el worktree de effect-reference
-- Actualizar el contexto de Effect desde el origen remoto (effect-smol)
-- Consultar patrones de Effect-TS en el código de referencia
-- Verificar que el worktree está sincronizado correctamente
+- Clonar las referencias locales de Effect v4 y Alchemy en una nueva máquina
+- Actualizar Effect desde `Effect-TS/effect` rama `main`
+- Actualizar Alchemy desde `alchemy-run/alchemy` rama `main`
+- Consultar patrones actuales directamente en los clones de referencia
+- Verificar que ambos clones depth-1 están sincronizados con sus upstreams
+
+## Fuentes Canónicas
+
+- `.effect-reference/effect` es un clon depth-1 de `https://github.com/Effect-TS/effect.git`, rama `main`, y es la referencia local de Effect v4.
+- Effect v3 corresponde a la rama `v3` del mismo repositorio `Effect-TS/effect`; no debe utilizarse como objetivo de la referencia v4.
+- `.effect-reference/alchemy` es un clon depth-1 de `https://github.com/alchemy-run/alchemy.git`, rama `main`, y es la referencia canónica de Alchemy next/alpha basada en Effect.
+- `alchemy-run/alchemy-async` es la implementación async anterior, no la referencia canónica actual.
 
 ## Critical Patterns
 
-### Protocolo 1: Setup en Nueva Máquina (Clone & Mount)
+### Protocolo 1: Setup en Nueva Máquina
 
-Cuando el directorio `./effect-reference` no existe o el usuario menciona "nueva máquina":
+Los directorios de referencia están ignorados por Git y son clones independientes. No son worktrees del repositorio principal ni ramas huérfanas.
 
-```bash
-# 1. Obtener la rama huérfana del remoto
-git fetch origin effect-context
-
-# 2. Montar el worktree
-git worktree add .effect-reference origin/effect-context
-
-# 3. Confirmar lectura del archivo de migración
-cat .effect-reference/MIGRATION.md
-```
-
-### Protocolo 2: Actualización desde el Origen (Sync)
-
-Cuando el usuario pida "actualizar el contexto de Effect" o "traer lo último de effect-smol":
+Cuando uno de los directorios no exista o el usuario mencione una nueva máquina:
 
 ```bash
-# 1. Entrar al directorio del worktree
-cd .effect-reference
+# 1. Crear el directorio contenedor ignorado
+mkdir -p .effect-reference
 
-# 2. Descargar archivos más recientes (shallow)
-git fetch https://github.com/Effect-TS/effect-smol.git main --depth 1
+# 2. Clonar únicamente las ramas canónicas con profundidad 1
+git clone --depth 1 --branch main https://github.com/Effect-TS/effect.git .effect-reference/effect
+git clone --depth 1 --branch main https://github.com/alchemy-run/alchemy.git .effect-reference/alchemy
 
-# 3. Sobrescribir archivos locales sin mezclar historiales
-git checkout FETCH_HEAD -- .
-
-# 4. Limpiar archivos eliminados en el origen
-git add -A
-
-# 5. Crear commit de sincronización
-git commit -m "chore: sync latest effect-smol source"
-
-# 6. Sincronizar con el repositorio del usuario
-git push origin effect-context
-
-# 7. Volver a la raíz
-cd ..
+# 3. Confirmar remoto, rama y profundidad de cada clon
+git -C .effect-reference/effect remote get-url origin
+git -C .effect-reference/effect branch --show-current
+git -C .effect-reference/effect rev-parse --is-shallow-repository
+git -C .effect-reference/alchemy remote get-url origin
+git -C .effect-reference/alchemy branch --show-current
+git -C .effect-reference/alchemy rev-parse --is-shallow-repository
 ```
+
+Si uno de los clones ya existe, no volver a ejecutar `git clone` sobre ese directorio. Utilizar el protocolo de sincronización correspondiente.
+
+### Protocolo 2: Actualización desde los Orígenes
+
+Cuando el usuario pida actualizar el contexto, confirmar primero que cada clon esté limpio y apunte al remoto y rama esperados:
+
+```bash
+# Effect v4
+git -C .effect-reference/effect status --short --branch
+git -C .effect-reference/effect remote get-url origin
+git -C .effect-reference/effect branch --show-current
+git -C .effect-reference/effect pull --ff-only --depth 1 origin main
+
+# Alchemy next/alpha
+git -C .effect-reference/alchemy status --short --branch
+git -C .effect-reference/alchemy remote get-url origin
+git -C .effect-reference/alchemy branch --show-current
+git -C .effect-reference/alchemy pull --ff-only --depth 1 origin main
+```
+
+No sobrescribir cambios locales en los clones. Si `status --short` muestra cambios o `pull --ff-only` no puede avanzar, detenerse y resolver el estado explícitamente.
 
 ## Restricciones Críticas de Seguridad
 
-| Restricción             | Descripción                                                                                                     |
-| ----------------------- | --------------------------------------------------------------------------------------------------------------- |
-| **Aislamiento Total**   | Nunca hacer `git merge` entre la rama actual y `effect-context`                                                 |
-| **Modo Solo-Lectura**   | No sugerir cambios de código dentro de `./effect-reference`                                                     |
-| **Limpieza de Commits** | Los archivos de `.effect-reference` NUNCA deben aparecer en `git status` de ramas de desarrollo (`dev`, `main`) |
+| Restricción            | Descripción                                                                                                          |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| **Aislamiento Total**  | Nunca hacer `git merge` entre los clones de referencia y las ramas de desarrollo                                    |
+| **Modo Solo-Lectura**  | No sugerir cambios de código dentro de `.effect-reference/effect` o `.effect-reference/alchemy`                     |
+| **Clones Independientes** | No montar estas referencias como worktrees ni mantenerlas mediante ramas huérfanas del repositorio principal     |
+| **Contenido Ignorado** | Los archivos de `.effect-reference` no deben incluirse en commits de las ramas de desarrollo                         |
+| **Sincronización Segura** | Actualizar únicamente clones limpios mediante fast-forward desde la rama `main` de su origin esperado             |
 
 ## Verificación del Estado
 
 ```bash
-# Verificar que es un worktree válido
-cd .effect-reference && git status
+# Verificar remoto, rama y clon shallow de Effect
+git -C .effect-reference/effect remote get-url origin
+git -C .effect-reference/effect branch --show-current
+git -C .effect-reference/effect rev-parse --is-shallow-repository
+git -C .effect-reference/effect rev-parse HEAD
+git ls-remote https://github.com/Effect-TS/effect.git refs/heads/main
 
-# Ver ramas disponibles
-git branch -a
+# Verificar remoto, rama y clon shallow de Alchemy
+git -C .effect-reference/alchemy remote get-url origin
+git -C .effect-reference/alchemy branch --show-current
+git -C .effect-reference/alchemy rev-parse --is-shallow-repository
+git -C .effect-reference/alchemy rev-parse HEAD
+git ls-remote https://github.com/alchemy-run/alchemy.git refs/heads/main
 
-# Verificar que está en rama effect-context
-git rev-parse --abbrev-ref HEAD
+# Ambos clones deben permanecer limpios
+git -C .effect-reference/effect status --short --branch
+git -C .effect-reference/alchemy status --short --branch
 ```
 
 ## Commands
 
 ```bash
 # Setup inicial
-git fetch origin effect-context && git worktree add .effect-reference origin/effect-context
+git clone --depth 1 --branch main https://github.com/Effect-TS/effect.git .effect-reference/effect
+git clone --depth 1 --branch main https://github.com/alchemy-run/alchemy.git .effect-reference/alchemy
 
 # Sincronizar con latest
-cd .effect-reference && git fetch https://github.com/Effect-TS/effect-smol.git main --depth 1 && git checkout FETCH_HEAD -- . && git add -A && git commit -m "chore: sync latest effect-smol source" && git push origin effect-context && cd ..
+git -C .effect-reference/effect pull --ff-only --depth 1 origin main
+git -C .effect-reference/alchemy pull --ff-only --depth 1 origin main
 
 # Verificar estado
-cd .effect-reference && git status && git branch
+git -C .effect-reference/effect status --short --branch
+git -C .effect-reference/alchemy status --short --branch
 ```
 
 ## Recursos
 
-- **Referencia Effect**: [effect-reference/](./effect-reference/)
-- **Guía de Migración**: [effect-reference/MIGRATION.md](./effect-reference/MIGRATION.md)
+- **Referencia Effect v4**: [.effect-reference/effect/](../../../.effect-reference/effect/)
+- **Guía de Migración de Effect**: [.effect-reference/effect/MIGRATION.md](../../../.effect-reference/effect/MIGRATION.md)
+- **Referencia Alchemy next/alpha**: [.effect-reference/alchemy/](../../../.effect-reference/alchemy/)

--- a/.agent/skills/effect-context-manager/SKILL.md
+++ b/.agent/skills/effect-context-manager/SKILL.md
@@ -73,13 +73,13 @@ No sobrescribir cambios locales en los clones. Si `status --short` muestra cambi
 
 ## Restricciones Críticas de Seguridad
 
-| Restricción            | Descripción                                                                                                          |
-| ---------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| **Aislamiento Total**  | Nunca hacer `git merge` entre los clones de referencia y las ramas de desarrollo                                    |
-| **Modo Solo-Lectura**  | No sugerir cambios de código dentro de `.effect-reference/effect` o `.effect-reference/alchemy`                     |
-| **Clones Independientes** | No montar estas referencias como worktrees ni mantenerlas mediante ramas huérfanas del repositorio principal     |
-| **Contenido Ignorado** | Los archivos de `.effect-reference` no deben incluirse en commits de las ramas de desarrollo                         |
-| **Sincronización Segura** | Actualizar únicamente clones limpios mediante fast-forward desde la rama `main` de su origin esperado             |
+| Restricción               | Descripción                                                                                                  |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| **Aislamiento Total**     | Nunca hacer `git merge` entre los clones de referencia y las ramas de desarrollo                             |
+| **Modo Solo-Lectura**     | No sugerir cambios de código dentro de `.effect-reference/effect` o `.effect-reference/alchemy`              |
+| **Clones Independientes** | No montar estas referencias como worktrees ni mantenerlas mediante ramas huérfanas del repositorio principal |
+| **Contenido Ignorado**    | Los archivos de `.effect-reference` no deben incluirse en commits de las ramas de desarrollo                 |
+| **Sincronización Segura** | Actualizar únicamente clones limpios mediante fast-forward desde la rama `main` de su origin esperado        |
 
 ## Verificación del Estado
 

--- a/.agent/skills/effect-context-manager/SKILL.md
+++ b/.agent/skills/effect-context-manager/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: effect-context-manager
 description: >
-  Gestiona los clones locales de referencia de Effect v4 y Alchemy alojados en ./.effect-reference.
-  Trigger: Cuando se necesita consultar el código de Effect o Alchemy, actualizar el contexto, o configurar una nueva máquina.
+  Manages the local Effect v4 and Alchemy reference clones hosted in ./.effect-reference.
+  Trigger: When Effect or Alchemy code needs to be consulted, the context needs to be updated, or a new machine needs to be set up.
 license: Apache-2.0
 metadata:
   author: gentleman-programming
@@ -11,36 +11,36 @@ metadata:
 
 ## When to Use
 
-- Clonar las referencias locales de Effect v4 y Alchemy en una nueva máquina
-- Actualizar Effect desde `Effect-TS/effect` rama `main`
-- Actualizar Alchemy desde `alchemy-run/alchemy` rama `main`
-- Consultar patrones actuales directamente en los clones de referencia
-- Verificar que ambos clones depth-1 están sincronizados con sus upstreams
+- Clone the local Effect v4 and Alchemy references on a new machine
+- Update Effect from the `main` branch of `Effect-TS/effect`
+- Update Alchemy from the `main` branch of `alchemy-run/alchemy`
+- Consult current patterns directly in the reference clones
+- Verify that both depth-1 clones are synchronized with their upstreams
 
-## Fuentes Canónicas
+## Canonical Sources
 
-- `.effect-reference/effect` es un clon depth-1 de `https://github.com/Effect-TS/effect.git`, rama `main`, y es la referencia local de Effect v4.
-- Effect v3 corresponde a la rama `v3` del mismo repositorio `Effect-TS/effect`; no debe utilizarse como objetivo de la referencia v4.
-- `.effect-reference/alchemy` es un clon depth-1 de `https://github.com/alchemy-run/alchemy.git`, rama `main`, y es la referencia canónica de Alchemy next/alpha basada en Effect.
-- `alchemy-run/alchemy-async` es la implementación async anterior, no la referencia canónica actual.
+- `.effect-reference/effect` is a depth-1 clone of the `main` branch of `https://github.com/Effect-TS/effect.git` and is the local Effect v4 reference.
+- Effect v3 corresponds to the `v3` branch of the same `Effect-TS/effect` repository; it must not be used as the target for the v4 reference.
+- `.effect-reference/alchemy` is a depth-1 clone of the `main` branch of `https://github.com/alchemy-run/alchemy.git` and is the canonical Effect-based Alchemy next/alpha reference.
+- `alchemy-run/alchemy-async` is the former async implementation, not the current canonical reference.
 
 ## Critical Patterns
 
-### Protocolo 1: Setup en Nueva Máquina
+### Protocol 1: Setup on a New Machine
 
-Los directorios de referencia están ignorados por Git y son clones independientes. No son worktrees del repositorio principal ni ramas huérfanas.
+The reference directories are ignored by Git and are independent clones. They are neither worktrees of the main repository nor orphan branches.
 
-Cuando uno de los directorios no exista o el usuario mencione una nueva máquina:
+When one of the directories does not exist or the user mentions a new machine:
 
 ```bash
-# 1. Crear el directorio contenedor ignorado
+# 1. Create the ignored container directory
 mkdir -p .effect-reference
 
-# 2. Clonar únicamente las ramas canónicas con profundidad 1
+# 2. Clone only the canonical branches with depth 1
 git clone --depth 1 --branch main https://github.com/Effect-TS/effect.git .effect-reference/effect
 git clone --depth 1 --branch main https://github.com/alchemy-run/alchemy.git .effect-reference/alchemy
 
-# 3. Confirmar remoto, rama y profundidad de cada clon
+# 3. Confirm the remote, branch, and depth of each clone
 git -C .effect-reference/effect remote get-url origin
 git -C .effect-reference/effect branch --show-current
 git -C .effect-reference/effect rev-parse --is-shallow-repository
@@ -49,11 +49,11 @@ git -C .effect-reference/alchemy branch --show-current
 git -C .effect-reference/alchemy rev-parse --is-shallow-repository
 ```
 
-Si uno de los clones ya existe, no volver a ejecutar `git clone` sobre ese directorio. Utilizar el protocolo de sincronización correspondiente.
+If one of the clones already exists, do not run `git clone` again in that directory. Use the corresponding synchronization protocol.
 
-### Protocolo 2: Actualización desde los Orígenes
+### Protocol 2: Update from Upstream Sources
 
-Cuando el usuario pida actualizar el contexto, confirmar primero que cada clon esté limpio y apunte al remoto y rama esperados:
+When the user asks to update the context, first confirm that each clone is clean and points to the expected remote and branch:
 
 ```bash
 # Effect v4
@@ -69,36 +69,36 @@ git -C .effect-reference/alchemy branch --show-current
 git -C .effect-reference/alchemy pull --ff-only --depth 1 origin main
 ```
 
-No sobrescribir cambios locales en los clones. Si `status --short` muestra cambios o `pull --ff-only` no puede avanzar, detenerse y resolver el estado explícitamente.
+Do not overwrite local changes in the clones. If `status --short` shows changes or `pull --ff-only` cannot fast-forward, stop and resolve the state explicitly.
 
-## Restricciones Críticas de Seguridad
+## Critical Safety Constraints
 
-| Restricción               | Descripción                                                                                                  |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| **Aislamiento Total**     | Nunca hacer `git merge` entre los clones de referencia y las ramas de desarrollo                             |
-| **Modo Solo-Lectura**     | No sugerir cambios de código dentro de `.effect-reference/effect` o `.effect-reference/alchemy`              |
-| **Clones Independientes** | No montar estas referencias como worktrees ni mantenerlas mediante ramas huérfanas del repositorio principal |
-| **Contenido Ignorado**    | Los archivos de `.effect-reference` no deben incluirse en commits de las ramas de desarrollo                 |
-| **Sincronización Segura** | Actualizar únicamente clones limpios mediante fast-forward desde la rama `main` de su origin esperado        |
+| Constraint               | Description                                                                                                |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------- |
+| **Total Isolation**      | Never run `git merge` between the reference clones and the development branches                            |
+| **Read-Only Mode**       | Do not suggest code changes inside `.effect-reference/effect` or `.effect-reference/alchemy`               |
+| **Independent Clones**   | Do not mount these references as worktrees or maintain them through orphan branches of the main repository |
+| **Ignored Content**      | Files under `.effect-reference` must not be included in commits on development branches                    |
+| **Safe Synchronization** | Update only clean clones by fast-forwarding from the `main` branch of their expected `origin`              |
 
-## Verificación del Estado
+## Status Verification
 
 ```bash
-# Verificar remoto, rama y clon shallow de Effect
+# Verify the remote, branch, and shallow clone status of Effect
 git -C .effect-reference/effect remote get-url origin
 git -C .effect-reference/effect branch --show-current
 git -C .effect-reference/effect rev-parse --is-shallow-repository
 git -C .effect-reference/effect rev-parse HEAD
 git ls-remote https://github.com/Effect-TS/effect.git refs/heads/main
 
-# Verificar remoto, rama y clon shallow de Alchemy
+# Verify the remote, branch, and shallow clone status of Alchemy
 git -C .effect-reference/alchemy remote get-url origin
 git -C .effect-reference/alchemy branch --show-current
 git -C .effect-reference/alchemy rev-parse --is-shallow-repository
 git -C .effect-reference/alchemy rev-parse HEAD
 git ls-remote https://github.com/alchemy-run/alchemy.git refs/heads/main
 
-# Ambos clones deben permanecer limpios
+# Both clones must remain clean
 git -C .effect-reference/effect status --short --branch
 git -C .effect-reference/alchemy status --short --branch
 ```
@@ -106,21 +106,21 @@ git -C .effect-reference/alchemy status --short --branch
 ## Commands
 
 ```bash
-# Setup inicial
+# Initial setup
 git clone --depth 1 --branch main https://github.com/Effect-TS/effect.git .effect-reference/effect
 git clone --depth 1 --branch main https://github.com/alchemy-run/alchemy.git .effect-reference/alchemy
 
-# Sincronizar con latest
+# Synchronize with the latest upstream state
 git -C .effect-reference/effect pull --ff-only --depth 1 origin main
 git -C .effect-reference/alchemy pull --ff-only --depth 1 origin main
 
-# Verificar estado
+# Verify status
 git -C .effect-reference/effect status --short --branch
 git -C .effect-reference/alchemy status --short --branch
 ```
 
-## Recursos
+## Resources
 
-- **Referencia Effect v4**: [.effect-reference/effect/](../../../.effect-reference/effect/)
-- **Guía de Migración de Effect**: [.effect-reference/effect/MIGRATION.md](../../../.effect-reference/effect/MIGRATION.md)
-- **Referencia Alchemy next/alpha**: [.effect-reference/alchemy/](../../../.effect-reference/alchemy/)
+- **Effect v4 Reference**: [.effect-reference/effect/](../../../.effect-reference/effect/)
+- **Effect Migration Guide**: [.effect-reference/effect/MIGRATION.md](../../../.effect-reference/effect/MIGRATION.md)
+- **Alchemy next/alpha Reference**: [.effect-reference/alchemy/](../../../.effect-reference/alchemy/)

--- a/.agent/skills/effect-pattern-discovery/SKILL.md
+++ b/.agent/skills/effect-pattern-discovery/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: effect-pattern-discovery
 description: >
-  Effect-TS patterns sourced from effect-smol reference implementation.
+  Effect-TS patterns sourced from the Effect v4 reference on Effect-TS/effect main.
   Trigger: When implementing Effect, Layer, Schema, Pipe, Context, or error handling patterns.
 license: Apache-2.0
 metadata:
@@ -173,23 +173,31 @@ const AppLayer = UserServiceLive.pipe(
 const CombinedLayer = Layer.merge(UserServiceLive, DatabaseServiceLive)
 ```
 
+## Reference Selection
+
+- `.effect-reference/effect` is the ignored, standalone, depth-1 clone of `https://github.com/Effect-TS/effect.git` on `main` and is the canonical Effect v4 source.
+- Effect v3 lives on the `v3` branch of the same `Effect-TS/effect` repository.
+- `.effect-reference/alchemy` is the ignored, standalone, depth-1 clone of `https://github.com/alchemy-run/alchemy.git` on `main` and is the canonical Effect-based Alchemy next/alpha reference.
+- `alchemy-run/alchemy-async` is the former async implementation; do not use it as the canonical current Alchemy reference.
+
 ## Commands
 
 ```bash
-# Scan for similar patterns in effect-smol
-ls .effect-reference/packages/effect/src/
+# Scan for similar patterns in the Effect v4 reference
+ls .effect-reference/effect/packages/effect/src/
 
 # Check internal implementations
-cat .effect-reference/packages/effect/src/internal/effect.ts
+cat .effect-reference/effect/packages/effect/src/internal/effect.ts
 
 # Look at module exports
-cat .effect-reference/packages/effect/src/index.ts
+cat .effect-reference/effect/packages/effect/src/index.ts
+
+# Explore current Effect-based Alchemy patterns
+ls .effect-reference/alchemy/
 ```
 
 ## Resources
 
-- **effect-smol source**: `.effect-reference/packages/effect/src/`
-- **Pattern docs**: `.effect-reference/.patterns/`
-- **Error handling**: `.effect-reference/.patterns/error-handling.md`
-- **Module organization**: `.effect-reference/.patterns/module-organization.md`
-- **Library development**: `.effect-reference/.patterns/effect-library-development.md`
+- **Effect v4 source**: `.effect-reference/effect/packages/effect/src/`
+- **Effect migration guide**: `.effect-reference/effect/MIGRATION.md`
+- **Alchemy next/alpha source**: `.effect-reference/alchemy/`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,14 +24,16 @@
 
 ## Effect-TS Pattern Discovery
 
-This project uses effect-smol as the canonical source for Effect patterns.
+This project uses the `main` branch of [Effect-TS/effect](https://github.com/Effect-TS/effect.git) as the canonical Effect v4 source. Effect v3 is maintained on the `v3` branch of that same repository.
 
-| Skill                      | Description                         | Location                                                                                  |
-| -------------------------- | ----------------------------------- | ----------------------------------------------------------------------------------------- |
-| `effect-context-manager`   | Setup & sync Effect v4 reference    | [.agent/skills/effect-context-manager](.agent/skills/effect-context-manager/SKILL.md)     |
-| `effect-pattern-discovery` | Effect-TS patterns from effect-smol | [.agent/skills/effect-pattern-discovery](.agent/skills/effect-pattern-discovery/SKILL.md) |
+| Skill                      | Description                              | Location                                                                                  |
+| -------------------------- | ---------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `effect-context-manager`   | Setup & sync local reference clones      | [.agent/skills/effect-context-manager](.agent/skills/effect-context-manager/SKILL.md)     |
+| `effect-pattern-discovery` | Effect-TS patterns from Effect v4 source | [.agent/skills/effect-pattern-discovery](.agent/skills/effect-pattern-discovery/SKILL.md) |
 
-**Reference Directory**: `.effect-reference/` contains the effect-smol source code mounted as a git worktree.
+**Effect Reference**: `.effect-reference/effect/` is an ignored, standalone, depth-1 clone of `https://github.com/Effect-TS/effect.git` on `main`.
+
+**Alchemy Reference**: `.effect-reference/alchemy/` is an ignored, standalone, depth-1 clone of [`alchemy-run/alchemy`](https://github.com/alchemy-run/alchemy.git) on `main`, and is the canonical Effect-based Alchemy next/alpha reference. [`alchemy-run/alchemy-async`](https://github.com/alchemy-run/alchemy-async) is the former async implementation.
 
 ## Hatchet + Effect Conventions
 

--- a/migration-prisma-v4.md
+++ b/migration-prisma-v4.md
@@ -15,9 +15,11 @@ El objetivo de este documento es definir los requerimientos para completar la mi
 
 ## 2. Contexto Técnico y Herramientas de IA
 
-- **Worktree Skill Activo:** El agente de IA cuenta con la habilidad de consultar el directorio `.effect-reference` (un git worktree local apuntando a `effect-smol` / `effect` v4 con `--depth 1`).
-- **Fuentes de Verdad:** - `MIGRATION.md` interno de la librería.
-  - Patrones arquitectónicos actuales encontrados directamente en el código fuente del worktree.
+- **Skill de Referencia Activo:** El agente de IA puede consultar `.effect-reference/effect`, un clon independiente, ignorado y depth-1 de `https://github.com/Effect-TS/effect.git` rama `main`, como fuente canónica de Effect v4. Effect v3 corresponde a la rama `v3` del mismo repositorio.
+- **Referencia de Alchemy:** `.effect-reference/alchemy` es un clon independiente, ignorado y depth-1 de `https://github.com/alchemy-run/alchemy.git` rama `main`, la referencia canónica de Alchemy next/alpha basada en Effect. `alchemy-run/alchemy-async` es la implementación async anterior.
+- **Fuentes de Verdad:**
+  - `MIGRATION.md` interno de la librería.
+  - Patrones arquitectónicos actuales encontrados directamente en los clones locales de referencia.
 - **Estado Actual:** El CLI y los servicios base están parcialmente migrados. Existe un bloqueante crítico de inyección de dependencias / manejo de errores en el `make` de `/packages/prisma/src/services/generator-service.ts`.
 
 ## 3. Estrategia de Ramas y Soporte Técnico


### PR DESCRIPTION
Closes #86

## Type

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation only
- [ ] Code refactoring
- [x] Maintenance/tooling
- [ ] Breaking change

## Summary

- Rename the local Effect reference from `.effect-reference/effect-smol` to `.effect-reference/effect`.
- Point Effect reference workflows at the depth-1 `Effect-TS/effect` `main` checkout and document v3 on the `v3` branch.
- Document the current Effect-based Alchemy reference and distinguish it from `alchemy-async`.
- Standardize every project-local skill on English technical prose.

## Changes

| File | Change |
|------|--------|
| `AGENTS.md` | Document canonical Effect and Alchemy reference repositories and paths. |
| `.agent/skills/effect-context-manager/SKILL.md` | Use standalone shallow clones and provide all skill instructions in English. |
| `.agent/skills/effect-pattern-discovery/SKILL.md` | Update pattern-discovery paths and upstream version guidance; verified it is fully English. |
| `migration-prisma-v4.md` | Correct local reference paths and repository descriptions. |

## Test Plan

- [x] `dprint check` for every project-local `SKILL.md`
- [x] `git diff --check`
- [x] Verified both local reference clones use `main`, are shallow, and match live upstream HEADs.
- [x] Verified tracked guidance contains no `.effect-reference/effect-smol` references.
- [x] Verified every project-local skill contains English technical prose.
- [x] Skills were reviewed by fresh readability and reliability reviewers.

## Contributor Checklist

- [x] Linked an approved issue
- [x] Added exactly one `type:*` label
- [x] No modified shell scripts require shellcheck
- [x] Skills tested in at least one agent
- [x] Docs updated for the workflow change
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
